### PR TITLE
JCSG history examples

### DIFF
--- a/examples/JCSG/README.md
+++ b/examples/JCSG/README.md
@@ -1,0 +1,12 @@
+The jcsg_history.tar.gz tarball contains copies of original JCSG "structure gallery" history of deposited PDB structures. Some clean-up modifications have been made to make them useable via simple file:// URI). Just unpack and look at the HTML files.
+
+---
+
+Another way of browsing the now defunct www.jcsg.org website is to use the wayback machine at archive.org, e.g. [https://web.archive.org/web/20110721031443/http://www.jcsg.org/](https://web.archive.org/web/20110721031443/http://www.jcsg.org/)
+
+---
+
+* [Elsliger, M.A., Deacon, A.M., Godzik, A., Lesley, S.A., Wooley, J., Wüthrich, K. and Wilson, I.A., 2010. The JCSG high-throughput structural biology pipeline. Acta Crystallographica Section F: Structural Biology and Crystallization Communications, 66(10), pp.1137-1142.](https://dx.doi.org/10.1107/S1744309110038212)
+* [van den Bedem, H., Wolf, G., Xu, Q. and Deacon, A.M., 2011. Distributed structure determination at the JCSG. Acta Crystallographica Section D: Biological Crystallography, 67(4), pp.368-375.](https://dx.doi.org/10.1107/S0907444910039934)
+* [Krishna, S., Weekes, D., Bakolitsa, C., Elsliger, M.A., Wilson, I.A., Godzik, A. and Wooley, J., 2010. TOPSAN: use of a collaborative environment for annotating, analyzing and disseminating data on JCSG and PSI structures. Acta Crystallographica Section F: Structural Biology and Crystallization Communications, 66(10), pp.1143-1147.](https://dx.doi.org/10.1107/S1744309110035736)
+* [Weiss, M.S. and Einspahr, H., 2010. Publishing structural genomics results: the JCSG Special Issue. Acta Crystallographica Section F: Structural Biology and Crystallization Communications, 66(11), pp.1406-1406.](https://doi.org/10.1107/S1744309110043733)


### PR DESCRIPTION
The full set of (nearly) all deposited PDB entries from JCSG and their target history representation.