### PR TITLE
Ed develop

### DIFF
--- a/contributions/IcebearShipment/ShipmentSchema.json
+++ b/contributions/IcebearShipment/ShipmentSchema.json
@@ -382,6 +382,7 @@
         "proteinUuid": {
           "type": "string",
           "format": "uuid",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
           "description": "The UUID of the protein in this sample. It is an error if the JSON defines no protein identified by this UUID.",
           "comment": "<p>Assumes only one protein per sample. If multiple can be present, redefine as per ligands.</p><p>Can the UUID refer to a previously-sent protein?</p>"
         },
@@ -610,7 +611,8 @@
         "uuid": {
           "description": "The unique identifier for the parent object.",
           "type": "string",
-          "format": "uuid"
+          "format": "uuid",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         },
         "sendersId": {
           "description": "The ID of the parent object in the sender's system",

--- a/docs/examples/Shipment_multiPositionPins.json
+++ b/docs/examples/Shipment_multiPositionPins.json
@@ -12,7 +12,6 @@
       },
       "version": "0.6.4",
       "mxlimsType": "Shipment",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "2296f23d-0f3c-2c96-b3d1-b908984ec709"
     }
   },
@@ -21,7 +20,6 @@
       "containerRef": { "$ref": "#/Shipment/Shipment1" },
       "version": "0.6.4",
       "mxlimsType": "Dewar",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "2296f23a-dce0-2560-baac-f1b23ec9e0cb"
     }
   },
@@ -31,7 +29,6 @@
       "containerRef": { "$ref": "#/Dewar/Dewar1" },
       "version": "0.6.4",
       "mxlimsType": "Puck",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "2296f23a-dce0-2560-baac-f1b23ec9e0aa"
     }
   },
@@ -42,7 +39,6 @@
       "containerRef": { "$ref": "#/Puck/Puck1" },
       "version": "0.6.4",
       "mxlimsType": "MultiPin",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "2296f23a-dce0-2560-baac-f1b23ec9e0dd"
     }
   },
@@ -53,7 +49,6 @@
       "sampleRef": { "$ref": "#/MacromoleculeSample/MacromoleculeSample1" },
       "version": "0.6.4",
       "mxlimsType": "PinPosition",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "2296f23a-dce0-2560-baac-f1b23ec9e011"
     },
     "PinPosition2": {
@@ -62,7 +57,6 @@
       "sampleRef": { "$ref": "#/MacromoleculeSample/MacromoleculeSample1" },
       "version": "0.6.4",
       "mxlimsType": "PinPosition",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "2296f23a-dce0-2560-baac-f1b23ec9e044"
     }
   },
@@ -71,7 +65,6 @@
       "acronym": "LMTIM",
       "version": "0.6.4",
       "mxlimsType": "Macromolecule",
-      "mxlimsBaseType": "PreparedSample",
       "uuid": "0196f23a-dce0-2560-baac-f1b23ec9e055"
     }
   },
@@ -81,7 +74,6 @@
       "macromoleculeRef": { "$ref":"#/Macromolecule/Macromolecule1" },
       "version": "0.6.4",
       "mxlimsType": "MacromoleculeSample",
-      "mxlimsBaseType": "PreparedSample",
       "uuid": "2296f23a-dce0-2560-baac-f1b23ec9e022",
       "identifiers": {
         "dnaSequence": "CGT CAT GCA TCA TCA GCT AGC TAG CAT CAT CGA TCA CTG ACG TAC TAC GTC AGT CGA TGC TGA CAA"

--- a/docs/examples/Shipment_plates.json
+++ b/docs/examples/Shipment_plates.json
@@ -45,6 +45,7 @@
   "WellDrop": {
     "WellDrop1": {
       "dropNumber": 1,
+      "name": "9098_A01_1",
       "containerRef": { "$ref": "#/PlateWell/PlateWell1" },
       "sampleRef": { "$ref": "#/MacromoleculeSample/MacromoleculeSample1" },
       "version": "0.6.4",

--- a/docs/examples/Shipment_plates.json
+++ b/docs/examples/Shipment_plates.json
@@ -14,7 +14,6 @@
       },
       "version": "0.6.4",
       "mxlimsType": "Shipment",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "4a96f23d-0f3c-2c96-b3d1-b908984ec709"
     }
   },
@@ -30,7 +29,6 @@
       "containerRef": { "$ref": "#/Shipment/Shipment1" },
       "version": "0.6.4",
       "mxlimsType": "Plate",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "4a96f23a-dce0-2560-baac-f1b23ec9e0cb"
     }
   },
@@ -41,7 +39,6 @@
       "containerRef": { "$ref": "#/Plate/Plate1" },
       "version": "0.6.4",
       "mxlimsType": "PlateWell",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "4a96f23a-dce0-2560-baac-f1b23ec9e0aa"
     }
   },
@@ -52,7 +49,6 @@
       "sampleRef": { "$ref": "#/MacromoleculeSample/MacromoleculeSample1" },
       "version": "0.6.4",
       "mxlimsType": "WellDrop",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "4a96f23a-dce0-2560-baac-f1b23ec9e0dd"
     }
   },
@@ -61,7 +57,6 @@
       "acronym": "LMTIM",
       "version": "0.6.4",
       "mxlimsType": "Macromolecule",
-      "mxlimsBaseType": "PreparedSample",
       "uuid": "0196f23a-dce0-2560-baac-f1b23ec9e055"
     }
   },
@@ -71,7 +66,6 @@
       "macromoleculeRef": { "$ref":"#/Macromolecule/Macromolecule1" },
       "version": "0.6.4",
       "mxlimsType": "MacromoleculeSample",
-      "mxlimsBaseType": "PreparedSample",
       "uuid": "4a96f23a-dce0-2560-baac-f1b23ec9e022"
     }
   },
@@ -92,7 +86,6 @@
       },
       "version": "0.6.4",
       "mxlimsType": "DropRegion",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "4a96f23a-beef-2560-baac-f1b23ec9e420"
     }
   },
@@ -103,7 +96,6 @@
       "sampleRef":{ "$ref":"#/MacromoleculeSample/MacromoleculeSample1" },
       "version": "0.6.4",
       "mxlimsType": "Crystal",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "4a96f23a-dce0-2560-baac-f1b23ec9e066"
     }
   }

--- a/docs/examples/Shipment_singlePositionPins.json
+++ b/docs/examples/Shipment_singlePositionPins.json
@@ -12,16 +12,15 @@
       },
       "version": "0.6.4",
       "mxlimsType": "Shipment",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "0196f23d-0f3c-2c96-b3d1-b908984ec709"
     }
   },
   "Dewar": {
     "Dewar1": {
+      "barcode": "DLS-MX-1234",
       "containerRef": { "$ref": "#/Shipment/Shipment1" },
       "version": "0.6.4",
       "mxlimsType": "Dewar",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "0196f23a-dce0-2560-baac-f1b23ec9e0cb"
     }
   },
@@ -31,7 +30,6 @@
       "containerRef": { "$ref": "#/Dewar/Dewar1" },
       "version": "0.6.4",
       "mxlimsType": "Puck",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "0196f23a-dce0-2560-baac-f1b23ec9e0aa"
     }
   },
@@ -43,7 +41,6 @@
       "sampleRef": { "$ref": "#/MacromoleculeSample/MacromoleculeSample1" },
       "version": "0.6.4",
       "mxlimsType": "Pin",
-      "mxlimsBaseType": "LogisticalSample",
       "uuid": "0196f23a-dce0-2560-baac-f1b23ec9e0dd"
     }
   },
@@ -52,7 +49,6 @@
       "acronym": "LMTIM",
       "version": "0.6.4",
       "mxlimsType": "Macromolecule",
-      "mxlimsBaseType": "PreparedSample",
       "uuid": "0196f23a-dce0-2560-baac-f1b23ec9e055"
     }
   },
@@ -62,7 +58,6 @@
       "macromoleculeRef": { "$ref":"#/Macromolecule/Macromolecule1" },
       "version": "0.6.4",
       "mxlimsType": "MacromoleculeSample",
-      "mxlimsBaseType": "PreparedSample",
       "uuid": "0196f23a-dce0-2560-baac-f1b23ec9e022"
     }
   }

--- a/mxlims/schemas/core/Dataset.json
+++ b/mxlims/schemas/core/Dataset.json
@@ -8,19 +8,22 @@
             "description": "uuid for Dataset source",
             "title": "SourceId",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         },
         "derivedFromId": {
             "description": "uuid for Dataset from which Dataset is derived",
             "title": "DerivedFromId",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         },
         "logisticalSampleId": {
             "description": "uuid for LogisticalSample related to Dataset",
             "title": "LogisticalSampleId",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         }
     },
     "not": {

--- a/mxlims/schemas/core/Job.json
+++ b/mxlims/schemas/core/Job.json
@@ -8,19 +8,22 @@
             "description": "uuid for related sample",
             "title": "SampleId",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         },
         "startedFromId": {
             "description": "uuid for JOPb from which this Job was started",
             "title": "StartedFromId",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         },
         "logisticalSampleId": {
             "description": "uuid for LogisticalSample related to Job",
             "title": "LogisticalSampleId",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         },
         "referenceDataIds": {
             "type": "array",
@@ -28,7 +31,8 @@
             "title": "ReferenceDataId",
             "items": {
                 "type": "string",
-                "format": "uuid"
+                "format": "uuid",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
             }
         },
         "templateDataIds": {
@@ -37,7 +41,8 @@
             "title": "TemplateDataId",
             "items": {
                 "type": "string",
-                "format": "uuid"
+                "format": "uuid",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
             }
         },
         "inputDataIds": {
@@ -46,7 +51,8 @@
             "title": "InputDataId",
             "items": {
                 "type": "string",
-                "format": "uuid"
+                "format": "uuid",
+                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
             }
         }
     },

--- a/mxlims/schemas/core/LogisticalSample.json
+++ b/mxlims/schemas/core/LogisticalSample.json
@@ -8,13 +8,15 @@
             "description": "uuid for constituent sample",
             "title": "SampleId",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         },
         "containerId": {
             "description": "uuid for LogisticalSample container",
             "title": "containerId",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         }
     }
 }

--- a/mxlims/schemas/core/PreparedSample.json
+++ b/mxlims/schemas/core/PreparedSample.json
@@ -8,13 +8,15 @@
             "description": "uuid for medium making up PreparedSample",
             "title": "mediumId",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         },
         "mainComponentId": {
             "description": "uuid for main component (e.g. macromolecule) making up PreparedSample",
             "title": "mainComponentId",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         }
     }
 }

--- a/mxlims/schemas/data/MxlimsObjectData.json
+++ b/mxlims/schemas/data/MxlimsObjectData.json
@@ -19,7 +19,8 @@
             "description": "Permanent unique identifier string",
             "title": "Uuid",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         },
         "namespacedExtensions": {
             "description": "List of extensions to metadata, each defined in a NamespacedExtension schema",

--- a/mxlims/schemas/datatypes/DatasetStub.json
+++ b/mxlims/schemas/datatypes/DatasetStub.json
@@ -14,7 +14,8 @@
             "description": "Permanent unique identifier string of object referred to",
             "title": "Uuid",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         }
     },
     "required": [

--- a/mxlims/schemas/datatypes/ImageRegion.json
+++ b/mxlims/schemas/datatypes/ImageRegion.json
@@ -40,6 +40,7 @@
     },
     "required": [
         "region",
+        "image",
         "units"
     ],
     "additionalProperties": false

--- a/mxlims/schemas/datatypes/JobStub.json
+++ b/mxlims/schemas/datatypes/JobStub.json
@@ -14,7 +14,8 @@
             "description": "Permanent unique identifier string of object referred to",
             "title": "Uuid",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         }
     },
     "required": [

--- a/mxlims/schemas/datatypes/LogisticalSampleStub.json
+++ b/mxlims/schemas/datatypes/LogisticalSampleStub.json
@@ -14,7 +14,8 @@
             "description": "Permanent unique identifier string of object referred to",
             "title": "Uuid",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         }
     },
     "required": [

--- a/mxlims/schemas/datatypes/PreparedSampleStub.json
+++ b/mxlims/schemas/datatypes/PreparedSampleStub.json
@@ -14,7 +14,8 @@
             "description": "Permanent unique identifier string of object referred to",
             "title": "Uuid",
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         }
     },
     "required": [

--- a/mxlims/tools/php/ShipmentEncoder/doc/MinimalShipment.txt
+++ b/mxlims/tools/php/ShipmentEncoder/doc/MinimalShipment.txt
@@ -1,0 +1,26 @@
+To generate JSON for a simple one-pin shipment:
+
+//Get the encoder
+$encoder=new mxlims\tools\php\ShipmentEncoder\src\v0_6_4ShipmentEncoder();
+
+//Create the shipment with its proposal and session number
+$encoder->createShipment("mx1234", 1);
+
+//Set the lab contacts
+$encoder->setLabContactOutbound("Alice","alice@uni.edu");
+$encoder->setLabContactReturn("Bob","bob@uni.edu");
+
+//Add the macromolecule, with its protein acronym
+$macromolecule=$encoder->addMacromoleculeToShipment("PROTEIN1");
+
+//Add the dewar
+$dewar=$encoder->addDewarToShipment("DEWAR123");
+
+//Add a 16-position unipuck
+$puck=$encoder->addPuckToDewar($dewar['index'], "PUCK345", 16);
+
+//Add a pin and sample at puck position 1, with the macromolecule of interest
+$encoder->addSinglePinSampleToPuck($puck['index'], 1, $macromolecule['index'], 'PROTEIN1_sample1', 'HA00AA6789');
+
+//Get the MXLIMS shipment JSON
+$json=$encoder->encodeToJSON();

--- a/mxlims/tools/php/ShipmentEncoder/src/ShipmentEncoderInterface.php
+++ b/mxlims/tools/php/ShipmentEncoder/src/ShipmentEncoderInterface.php
@@ -1,0 +1,252 @@
+<?php
+namespace mxlims\tools\php\ShipmentEncoder\src;
+
+interface ShipmentEncoderInterface {
+
+	/**
+	 * Returns the MXLIMS version.
+	 * @return string The MXLIMS version.
+	 */
+	public function getVersion(): string;
+
+	/**
+	 * Gets an object in the shipment message, by its MXLIMS type and its (1-based) index).
+	 * @param string $mxlimsType The MXLIMS type.
+	 * @param int $index The index.
+	 * @return array|null The MXLIMS object, or null if not found.
+	 */
+	public function get(string $mxlimsType, int $index): ?array;
+
+	/**
+	 * Gets an object in the shipment message by its JSON path.
+	 * @param string|array $path. Either a path in the form "#/ObjectType/ObjectType123", or an array with a $ref property whose value is a JSON path in that form.
+	 * @throws \Exception
+	 */
+	public function getByJsonPath(string|array $path): ?array;
+
+	/**
+	 * Creates the basic shipment to which everything else will be added.
+	 * @param string $proposalCode The name of the proposal at the synchrotron (e.g., "mx4025").
+	 * @param int|null $sessionNumber The number of the session within the proposal, or null for unattended/mail-in collection.
+	 * @param string|null $uuid The UUID for the shipment. If not provided, this will be generated automatically.
+	 * @return array The shipment.
+	 * @throws \Exception if $proposalName isn't alphanumeric.
+	 */
+	public function createShipment(string $proposalCode, int $sessionNumber=null, string $uuid=null): array;
+
+	/**
+	 * Sets and returns the outbound lab contact for the shipment.
+	 * @param string $name The lab contact's name.
+	 * @param string|null $emailAddress The lab contact's email address.
+	 * @param string|null $phoneNumber The lab contact's phone number.
+	 * @return array The lab contact.
+	 * @throws \Exception if name is empty, or if both email address and phone number are empty.
+	 */
+	public function setLabContactOutbound(string $name, string $emailAddress=null, string $phoneNumber=null): array;
+
+	/**
+	 * Sets and returns the return lab contact for the shipment.
+	 * @param string $name The lab contact's name.
+	 * @param string|null $emailAddress The lab contact's email address.
+	 * @param string|null $phoneNumber The lab contact's phone number.
+	 * @return array The lab contact.
+	 * @throws \Exception if name is empty, or if both email address and phone number are empty.
+	 */
+	public function setLabContactReturn(string $name, string $emailAddress=null, string $phoneNumber=null): array;
+
+	/**
+	 * Adds a macromolecule to the shipment.
+	 * @param string $acronym The protein acronym (which identifies the macromolecule in the synchrotron's safety systems).
+	 * @param string|null $uuid A pre-existing UUID for this macromolecule. If not supplied, one will be generated.
+	 * @throws \Exception if the acronym is empty.
+	 */
+	public function addMacromoleculeToShipment(string $acronym, ?string $uuid=null): array;
+
+	/**
+	 * Adds a dewar to the shipment.
+	 * @param string|null $barcode The dewar barcode.
+	 * @param string|null $uuid An existing UUID for the dewar. If not supplied, one will be generated.
+	 * @return array
+	 * @throws \Exception if there are Plates in the Shipment
+	 */
+	public function addDewarToShipment(string $barcode=null, ?string $uuid=null): array;
+
+	/**
+	 * Adds a puck to a dewar.
+	 * @param int $dewarIndex The index of the dewar within the shipment message. This is the "index" property of the object returned from addDewarToShipment.
+	 * @param string $barcode The puck barcode.
+	 * @param int $numPositions The number of pin positions in the puck.
+	 * @param string|null $uuid An existing UUID for the puck. If not supplied, one will be generated.
+	 * @return array The puck.
+	 * @throws \Exception if the dewar cannot be found, or if $numPositions is not positive.
+	 */
+	public function addPuckToDewar(int $dewarIndex, string $barcode, int $numPositions, ?string $uuid=null): array;
+
+	/**
+	 * Adds a frozen crystal on a traditional loop, creating both Pin and MacromoleculeSample objects.
+	 * @param int $puckIndex The (1-based) index of the Puck within the top-level array).
+	 * @param int $puckPosition The (1-based) position of the pin within the puck.
+	 * @param int $macromoleculeIndex The (1-based) index of the sample's Macromolecule within the top-level array).
+	 * @param string $sampleName The name of the sample.
+	 * @param string|null $pinBarcode The barcode of the pin.
+	 * @param string|null $pinUuid An existing UUID for the pin. If not specified, one will be generated.
+	 * @param string|null $sampleUuid An existing UUID for the sample. If not specified, one will be generated.
+	 * @return array An array containing the sample and the pin.
+	 * @throws \Exception if the specified Puck or Macromolecule do not exist.
+	 * @throws \Exception if there are already multi-position pins in the shipment.
+	 * @throws \Exception if the puck position is out of range.
+	 * @throws \Exception if the position is already occupied.
+	 */
+	public function addSinglePinSampleToPuck(int $puckIndex, int $puckPosition, int $macromoleculeIndex, string $sampleName, ?string $pinBarcode=null, ?string $pinUuid=null, ?string $sampleUuid=null): array;
+
+	/**
+	 * Adds a single-position pin (such as a traditional loop) to a puck.
+	 * @param int $puckIndex The (1-based) index of the Puck within the top-level Puck array.
+	 * @param int $puckPosition The (1-based) position within the puck.
+	 * @param string|null $barcode The pin barcode.
+	 * @param string|null $uuid A previously-set UUID for the pin; if not supplied, one will be generated.
+	 * @return array The pin.
+	 * @throws \Exception if shipment already contains a multi-position pin.
+	 * @throws \Exception if puck does not exist in shipment.
+	 * @throws \Exception if number of pin positions is not a positive integer.
+	 * @throws \Exception if position in puck is out of range, or already filled.
+	 */
+	public function addSinglePositionPinToPuck(int $puckIndex, int $puckPosition, ?string $barcode=null, ?string $uuid=null): array;
+
+	/**
+	 * Adds a multi-position pin to a puck.
+	 * @param int $puckIndex The (1-based) index of the Puck within the top-level Puck array.
+	 * @param int $puckPosition The (1-based) position within the puck.
+	 * @param int $numPositions How many sample positions the pin has.
+	 * @param string|null $barcode The pin barcode.
+	 * @param string|null $uuid A previously-set UUID for the pin; if not supplied, one will be generated.
+	 * @return array The pin.
+	 * @throws \Exception if shipment already contains a single-position pin.
+	 * @throws \Exception if puck does not exist in shipment.
+	 * @throws \Exception if number of pin positions is not a positive integer.
+	 * @throws \Exception if position in puck is out of range, or already filled.
+	 */
+	public function addMultiPositionPinToPuck(int $puckIndex, int $puckPosition, int $numPositions, ?string $barcode=null, ?string $uuid=null): array;
+
+	/**
+	 * Adds a sample to a multi-position pin.
+	 * @param int $pinIndex The index of the pin.
+	 * @param int $pinPosition The position within the pin.
+	 * @param int $macromoleculeIndex The index of the macromolecule.
+	 * @param string $sampleName The name of the sample.
+	 * @param string|null $sampleUuid An existing UUID for the sample. If not supplied, one will be generated.
+	 * @return array An array containing the PinPosition and MacromoleculeSample.
+	 * @throws \Exception if pin or macromolecule does not exist.
+	 * @throws \Exception if pin position is already filled.
+	 * @throws \Exception if sample name already exists.
+	 */
+	public function addSampleToMultiPositionPin(int $pinIndex, int $pinPosition, int $macromoleculeIndex, string $sampleName, string $sampleUuid=null): array;
+
+	/**
+	 * Adds a plate to the shipment.
+	 * @param string $barcode The plate barcode.
+	 * @param int $rows The number of rows in the plate.
+	 * @param int $columns The number of columns in the plate.
+	 * @param int $subPositions The number of sub-positions in each well of the plate.
+	 * @param string|null $dropMapping A string describing the sender's mapping of drop numbers to well sub-positions. By default, this places drops above the reservoir in increasing drop number order from left to right.
+	 * @param string|null $uuid An existing UUID for the plate. If not provided, one will be generated.
+	 * @return array The plate.
+	 * @throws \Exception if barcode is not provided.
+	 * @throws \Exception if there is a Dewar in the shipment.
+	 * @throws \Exception if $rows, $columns or $subPositions are not positive integers.
+	 */
+	public function addPlateToShipment(string $barcode, int $rows, int $columns, int $subPositions, ?string $dropMapping=null, ?string $uuid = null): array;
+
+	/**
+	 * @param int $plateIndex The index of the plate.
+	 * @param int $rowNumber The row number of the well.
+	 * @param int $columnNumber The column number of the well.
+	 * @param string|null $uuid An existing UUID for the well; if not provided, one will be generated.
+	 * @return array The well.
+	 * @throws \Exception if the plate does not exist.
+	 * @throws \Exception if $rowNumber or $columnNumber are out of range for the plate type.
+	 * @throws \Exception if a well at this plate position already exists.
+	 */
+	public function addWellToPlate(int $plateIndex, int $rowNumber, int $columnNumber, ?string $uuid=null): array;
+
+	/**
+	 * Adds a drop to the plate well, creating a MacromoleculeSample.
+	 * @param int $wellIndex The index of the plate well.
+	 * @param int $dropNumber The number of the sub-position within the plate well.
+	 * @param int $macromoleculeIndex The index of the macromolecule.
+	 * @param string|null $name The name of the drop. Default is, e.g., "BARCODE_A01_3" for a drop in sub-position 3 of the top left well of plate with barcode "BARCODE".
+	 * @param string|null $uuid An existing UUID for the well. If not supplied, one will be generated.
+	 * @return array An array containing WellDrop and MacromoleculeSample.
+	 * @throws \Exception if there is no well with the specified index.
+	 * @throws \Exception if there is no macromolecule with the specified index.
+	 * @throws \Exception if the drop number is out of range for the plate type.
+	 * @throws \Exception if the well drop already exists.
+	 * @throws \Exception if the name already exists.
+	 */
+	public function addDropToPlateWell(int $wellIndex, int $dropNumber, int $macromoleculeIndex, ?string $name=null, ?string $uuid=null): array;
+
+	/**
+	 * Gets the plate well in the specified plate, with the specified row and column number.
+	 * @param int $plateIndex
+	 * @param int $rowNumber
+	 * @param int $columnNumber
+	 * @return array|null
+	 * @throws \Exception if no plate with index $plateIndex is found.
+	 */
+	public function getPlateWellByPosition(int $plateIndex, int $rowNumber, int $columnNumber): ?array;
+
+	/**
+	 * Gets the well drop in the specified plate, with the specified row, column and sub-position (drop) number.
+	 * @param int $plateIndex
+	 * @param int $rowNumber
+	 * @param int $columnNumber
+	 * @param int $dropNumber
+	 * @return array|null
+	 * @throws \Exception if no plate with index $plateIndex is found.
+	 */
+	public function getWellDropByPosition(int $plateIndex, int $rowNumber, int $columnNumber, int $dropNumber): ?array;
+
+
+	/**
+	 * Adds a point region. This may be either a plate region (defined relative to a fiducial mark) or an image region (defined
+	 *  as pixel co-ordinates on a supplied image).
+	 *
+	 * For plate regions: Leave $imageMimeType, $imageUrl and $imageData null. Co-ordinate units are assumed to be microns.
+	 *
+	 * For image regions. Specify $imageMimeType AND ($imageUrl XOR $imageData). Co-ordinate units are assumed to be pixels.
+	 * @param int $dropIndex
+	 * @param int $x The X co-ordinate
+	 * @param int $y The Y co-ordinate
+	 * @param string|null $imageMimeType
+	 * @param string|null $imageUrl
+	 * @param string|null $imageData
+	 * @return array
+	 * @throws \Exception if $x or $y is negative, or if addDropRegion throws an Exception.
+	 */
+	public function addPointDropRegionByPlateDropIndex(int $dropIndex, int $x, int $y, ?string $imageMimeType=null, ?string $imageUrl=null, ?string $imageData=null): array;
+
+	/**
+	 * Adds a crystal and associates it with an existing drop region in the shipment.
+	 * @param int $dropRegionIndex The index of the drop region marking this crystal.
+	 * @param string $name The name of the crystal.
+	 * @param string|null $uuid An existing UUID for the crystal. If not specified, one will be generated.
+	 * @return array The crystal object.
+	 * @throws \Exception if the specified drop region does not exist in the shipment.
+	 */
+	public function addCrystalToDropRegion(int $dropRegionIndex, string $name, ?string $uuid=null): array;
+
+	/**
+	 * Validates the shipment.
+	 * @return bool true if shipment is valid.
+	 * @throws \Exception if shipment is not valid - see the exception message for details.
+	 */
+	public function validate(): bool;
+
+	/**
+	 * Returns an MXLIMS-formatted ShipmentMessage.
+	 * @param bool $prettyPrint Whether to format the JSON to make it more human-readable.
+	 * @return string The shipment, encoded as JSON in MXLIMS format.
+	 * @throws \Exception if shipment does not validate.
+	 */
+	public function encodeToJson(bool $prettyPrint=false): string;
+}

--- a/mxlims/tools/php/ShipmentEncoder/src/v0_6_4ShipmentEncoder.php
+++ b/mxlims/tools/php/ShipmentEncoder/src/v0_6_4ShipmentEncoder.php
@@ -1,0 +1,769 @@
+<?php
+
+namespace mxlims\tools\php\ShipmentEncoder\src;
+
+include_once __DIR__.'/ShipmentEncoderInterface.php';
+
+class v0_6_4ShipmentEncoder implements ShipmentEncoderInterface {
+
+	/**
+	 * @var string $plateRowLabels Used to generate plate well/drop names, with A being the top row of a plate, B the next, etc.
+	 */
+	private string $plateRowLabels='-ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+	/**
+	 * @var array $shipmentMessage The shipment message will be built up here
+	 */
+	private array $shipmentMessage;
+
+	/**
+	 * Returns an array with the basic "mxlimsType", "version", and "uuid" parameters, generating the UUID if not supplied.
+	 * @param string $mxlimsType The type of object.
+	 * @param string|null $uuid A pre-existing UUID for the object. If not supplied, one will be generated.
+	 * @return array The base object.
+	 * @throws \Exception if $mxlimsType is not alphanumeric or does not start with a capital letter
+	 */
+	private function getBaseObject(string $mxlimsType, ?string $uuid=null): array {
+		if(!preg_match('/^[A-Z][a-zA-Z0-9]+$/', $mxlimsType)){
+			throw new \Exception("Bad mxlimsType $mxlimsType");
+		}
+		if(!$uuid){
+			$uuid=self::generateUuid();
+		}
+		return [
+			'mxlimsType' => $mxlimsType,
+			'version' => $this->getVersion(),
+			'uuid' => $uuid
+		];
+	}
+
+	/**
+	 * Generates a UUIDv7.
+	 * @return string the UUID.
+	 */
+	private function generateUuid(): string {
+		$timestamp = intval(microtime(true) * 1000);
+		return sprintf('%02x%02x%02x%02x-%02x%02x-%04x-%04x-%012x',
+			// first 48 bits are timestamp based
+			($timestamp >> 40) & 0xFF,
+			($timestamp >> 32) & 0xFF,
+			($timestamp >> 24) & 0xFF,
+			($timestamp >> 16) & 0xFF,
+			($timestamp >> 8) & 0xFF,
+			$timestamp & 0xFF,
+
+			// 16 bits: 4 bits for version (7) and 12 bits for rand_a
+			mt_rand(0, 0x0FFF) | 0x7000,
+
+			// 16 bits: 4 bits for variant where 2 bits are fixed 10 and next 2 are random to get (8-9, a-b)
+			// next 12 are random
+			mt_rand(0, 0x3FFF) | 0x8000,
+			// random 48 bits
+			mt_rand(0, 0xFFFFFFFFFFFF),
+		);
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::getVersion()
+	 */
+	public function getVersion(): string {
+		if(isset($this->version)){
+			return $this->version;
+		}
+		$parts=explode('\\', get_called_class());
+		$className=end($parts);
+		if(!preg_match('/\d+_\d+_\d+/', $className, $matches)){
+			throw new \Exception('Cannot determine version from class name');
+		}
+		$version=str_replace('_','.',$matches[0]);
+		$this->version=$version;
+		return $this->version;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::get()
+	 */
+	public function get(string $mxlimsType, int $index): ?array {
+		if(isset($this->shipmentMessage[$mxlimsType][$mxlimsType.$index])){
+			$obj=$this->shipmentMessage[$mxlimsType][$mxlimsType.$index];
+			$obj['index']=$index;
+			return $obj;
+		}
+		return null;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::getByJsonPath()
+	 * @throws \Exception
+	 */
+	public function getByJsonPath(string|array $path): ?array {
+		if(is_array($path)){
+			if(isset($path['$ref'])){
+				$path=$path['$ref'];
+			} else {
+				throw new \Exception('No $ref property');
+			}
+		}
+		if (!str_starts_with($path,'#/')) {
+			throw new \Exception('JSON path must start with #/');
+		}
+		$path = substr($path, 2);
+		$parts = explode('/', $path);
+		if (2 !== count($parts)) {
+			throw new \Exception('Too many parts in JSON path');
+		}
+		if (!str_starts_with($parts[1], $parts[0]) && !(int)substr($parts[1], strlen($parts[0]))) {
+			throw new \Exception('JSON path must be in the form #/ObjectType/ObjectType123');
+		}
+		$index=(int)substr($parts[1], strlen($parts[0]));
+		return $this->get($parts[0], $index);
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::createShipment()
+	 * @throws \Exception
+	 */
+	public function createShipment(string $proposalCode, ?int $sessionNumber=null, ?string $uuid=null): array {
+		if(!empty($this->shipmentMessage)){
+			throw new \Exception("Shipment already added to message");
+		}
+		if(!preg_match('/^[0-9A-Za-z]+$/', $proposalCode)){
+			throw new \Exception("Bad proposal code $proposalCode");
+		}
+		$shipment=$this->getBaseObject('Shipment', $uuid);
+		$shipment['proposalCode']=$proposalCode;
+		if($sessionNumber){
+			if($sessionNumber<1){
+				throw new \Exception("Session number must be a positive number");
+			}
+			$shipment['sessionNumber'] = $sessionNumber;
+		}
+		$this->shipmentMessage=[];
+		$this->setObjectToMessage($shipment);
+		return $shipment;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::setLabContactOutbound()
+	 * @throws \Exception
+	 */
+	public function setLabContactOutbound(string $name, ?string $emailAddress=null, ?string $phoneNumber=null): array {
+		return self::setLabContact('Outbound', $name, $emailAddress, $phoneNumber);
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::setLabContactReturn()
+	 * @throws \Exception
+	 */
+	public function setLabContactReturn(string $name, ?string $emailAddress=null, ?string $phoneNumber=null): array {
+		return self::setLabContact('Return', $name, $emailAddress, $phoneNumber);
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::addMacromoleculeToShipment()
+	 * @throws \Exception
+	 */
+	public function addMacromoleculeToShipment(string $acronym, ?string $uuid=null): array {
+		if(empty($acronym)){
+			throw new \Exception('Acronym cannot be empty.');
+		}
+		$macromolecule=$this->getBaseObject('Macromolecule', $uuid);
+		$macromolecule['acronym']=$acronym;
+		$this->setObjectToMessage($macromolecule);
+		return $macromolecule;
+	}
+
+
+	/**
+	 * Sets and returns the lab contact.
+	 * @param string $direction Whether this is the Outbound or Return lab contact.
+	 * @param string $name The lab contact's name.
+	 * @param string|null $emailAddress The lab contact's email address.
+	 * @param string|null $phoneNumber The lab contact's phone number.
+	 * @return array The lab contact.
+	 * @throws \Exception if name is empty, or if both email address and phone number are empty.
+	 * @throws \Exception if direction is not "Outbound" or "Return".
+	 * */
+	private function setLabContact(string $direction, string $name, ?string $emailAddress, ?string $phoneNumber): array {
+		if('Outbound'!==$direction && 'Return'!==$direction){ throw new \Exception('Bad lab contact direction'); }
+		if(empty($name)){ throw new \Exception("Name cannot be empty"); }
+		if(empty($emailAddress) && empty($phoneNumber)){ throw new \Exception("Email or phone number must be provided"); }
+		$labContact=[ 'name'=>$name ];
+		if($phoneNumber){ $labContact['phoneNumber']=$phoneNumber; }
+		if($emailAddress){ $labContact['emailAddress']=$emailAddress; }
+		$this->shipmentMessage['Shipment']['Shipment1']['labContact'.$direction]=$labContact;
+		return $labContact;
+	}
+
+	/**
+	 * Adds the supplied object to the shipment message, and adds an 'index' parameter indicating its (1-based) position
+	 * in the top-level array. The first Dewar, for example, will be added at #/Dewar/Dewar1 and will have "index":1.
+	 * @param $object array The object to add.
+	 * @return void
+	 */
+	private function setObjectToMessage(array &$object): void {
+		$type=$object['mxlimsType'];
+		if(!isset($this->shipmentMessage[$type])){
+			$this->shipmentMessage[$type]=[];
+		}
+		$index=count($this->shipmentMessage[$type])+1;
+		$this->shipmentMessage[$type][$type.$index]=$object;
+		$object['index']=$index;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::addDewarToShipment()
+	 * @throws \Exception
+	 */
+	public function addDewarToShipment(?string $barcode = null, ?string $uuid = null): array {
+		if(!isset($this->shipmentMessage['Shipment'])){
+			throw new \Exception("Call createShipment() before addDewarToShipment()");
+		}
+		if(array_key_exists("Plate", $this->shipmentMessage)){
+			throw new \Exception("Shipment contains Plates, cannot add Dewar");
+		}
+		$dewar=$this->getBaseObject('Dewar', $uuid);
+		if(!empty($barcode)){
+			$dewar['barcode']=$barcode;
+		}
+		$dewar['containerRef']=['$ref'=>'#/Shipment/Shipment1'];
+		$this->setObjectToMessage($dewar);
+		return $dewar;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::addPuckToDewar()
+	 * @throws \Exception
+	 */
+	public function addPuckToDewar(int $dewarIndex, string $barcode, int $numPositions, string $uuid = null): array {
+		if(!$this->get('Dewar',$dewarIndex)){
+			throw new \Exception("No dewar with index $dewarIndex");
+		}
+		if($numPositions<1){ throw new \Exception("Number of positions must be a positive integer"); }
+		$puck=$this->getBaseObject('Puck', $uuid);
+		$puck['containerRef']=['$ref'=>'#/Dewar/Dewar'.$dewarIndex];
+		$puck['numberPositions']=$numPositions;
+		$puck['barcode']=$barcode;
+		$this->setObjectToMessage($puck);
+		return $puck;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::addSinglePinSampleToPuck()
+	 * @throws \Exception
+	 */
+	public function addSinglePinSampleToPuck(int $puckIndex, int $puckPosition, int $macromoleculeIndex, string $sampleName, ?string $pinBarcode=null, ?string $pinUuid=null, ?string $sampleUuid=null): array {
+		$puck=$this->get('Puck',$puckIndex);
+		if(isset($this->shipmentMessage['MultiPin'])){ throw new \Exception("Cannot mix multi-position pins and traditional loops"); }
+		if(!$puck){ throw new \Exception("No puck with index $puckIndex"); }
+		if(!$this->get('Macromolecule',$macromoleculeIndex)){ throw new \Exception("No macromolecule with index $macromoleculeIndex"); }
+		if($puckPosition<1 || $puckPosition>$puck['numberPositions']){ throw new \Exception("Puck position must be between 1 and {$puck['numberPositions']}"); }
+		if(isset($this->shipmentMessage['Pin'])){
+			foreach($this->shipmentMessage['Pin'] as $pin){
+				if($pin['positionInPuck']===$puckPosition && $pin['containerRef']['$ref']==='#/Puck/Puck'.$puckIndex){
+					throw new \Exception("Puck index $puckIndex position $puckPosition is already filled");
+				}
+				if(!empty($pinBarcode) && $pinBarcode===$pin['barcode']){
+					throw new \Exception('Shipment already contains a pin with barcode '.$pinBarcode);
+				}
+			}
+		}
+		if(isset($this->shipmentMessage['MacromoleculeSample'])){
+			foreach($this->shipmentMessage['MacromoleculeSample'] as $sample){
+				if($sampleName===$sample['name']){
+					throw new \Exception('Shipment already contains a sample with name '.$pinBarcode);
+				}
+			}
+		}
+		$pin=$this->getBaseObject('Pin', $pinUuid);
+		if(!empty($pinBarcode)){ $pin['barcode']=$pinBarcode; }
+		$sample=$this->getBaseObject('MacromoleculeSample', $sampleUuid);
+		$sample['macromoleculeRef']=['$ref'=>'#/Macromolecule/Macromolecule'.$macromoleculeIndex];
+		$sample['name']=$sampleName;
+		$this->setObjectToMessage($sample);
+		$pin['positionInPuck']=$puckPosition;
+		$pin['containerRef']['$ref']='#/Puck/Puck'.$puckIndex;
+		$pin['sampleRef']['$ref']='#/MacromoleculeSample/MacromoleculeSample'.$sample['index'];
+		$this->setObjectToMessage($pin);
+		return [
+			'MacromoleculeSample'=>$sample,
+			'Pin'=>$pin
+		];
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::addSinglePositionPinToPuck()
+	 * @throws \Exception
+	 */
+	public function addSinglePositionPinToPuck(int $puckIndex, int $puckPosition, ?string $barcode=null, ?string $uuid=null, ?string $sampleUuid=null): array {
+		$puck=$this->get('Puck',$puckIndex);
+		if(isset($this->shipmentMessage['MultiPin'])){
+			throw new \Exception('Shipment contains multi-position pin. Cannot add single-position pins.');
+		}
+		if(!$puck){
+			throw new \Exception("No puck with index $puckIndex");
+		}
+		$puckPositions=$puck['numberPositions'];
+		if($puckPosition<1 || $puckPosition>$puckPositions){
+			throw new \Exception("Position in puck must be between 1 and $puckPositions");
+		}
+		$pin=$this->getBaseObject('Pin', $uuid);
+		$pin['positionInPuck']=$puckPosition;
+		$pin['containerRef']=['$ref'=>'#/Puck/Puck'.$puckIndex];
+		if(!empty($barcode)){
+			$pin['barcode']=$barcode;
+		}
+		if(isset($this->shipmentMessage['Pin'])){
+			foreach($this->shipmentMessage['Pin'] as $existing){
+				if($existing['containerRef']['$ref']==='#/Puck/Puck'.$puckIndex && $existing['positionInPuck']===$puckPosition){
+					throw new \Exception('Puck position is already filled');
+				}
+			}
+		}
+		$this->setObjectToMessage($pin);
+		return $pin;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::addMultiPositionPinToPuck()
+	 * @throws \Exception
+	 */
+	public function addMultiPositionPinToPuck(int $puckIndex, int $puckPosition, int $numPositions, ?string $barcode=null, ?string $uuid=null): array {
+		$puck=$this->get('Puck',$puckIndex);
+		if(isset($this->shipmentMessage['Pin'])){
+			throw new \Exception('Shipment contains single-position pin. Cannot add multi-position pins.');
+		}
+		if(!$puck){
+			throw new \Exception("No puck with index $puckIndex");
+		}
+		if($numPositions<1){
+			throw new \Exception('Number of positions must be a positive integer');
+		}
+		$puckPositions=$puck['numberPositions'];
+		if($puckPosition<1 || $puckPosition>$puckPositions){
+			throw new \Exception("Position in puck must be between 1 and $puckPositions");
+		}
+		$pin=$this->getBaseObject('MultiPin', $uuid);
+		$pin['positionInPuck']=$puckPosition;
+		$pin['numberPositions']=$numPositions;
+		$pin['containerRef']=['$ref'=>'#/Puck/Puck'.$puckIndex];
+		if(!empty($barcode)){
+			$pin['barcode']=$barcode;
+		}
+		if(isset($this->shipmentMessage['MultiPin'])){
+			foreach($this->shipmentMessage['MultiPin'] as $existing){
+				if($existing['containerRef']['$ref']==='#/Puck/Puck'.$puckIndex && $existing['positionInPuck']===$puckPosition){
+					throw new \Exception('Puck position is already filled');
+				}
+			}
+		}
+		$this->setObjectToMessage($pin);
+		return $pin;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::addSampleToMultiPositionPin()
+	 * @throws \Exception
+	 */
+	public function addSampleToMultiPositionPin(int $pinIndex, int $pinPosition, int $macromoleculeIndex, string $sampleName, ?string $sampleUuid=null): array {
+		if(!$this->get('MultiPin',$pinIndex)){
+			throw new \Exception('No pin with index '.$pinIndex);
+		}
+		if(!$this->get('Macromolecule',$macromoleculeIndex)){
+			throw new \Exception('No macromolecule with index '.$pinIndex);
+		}
+		if(isset($this->shipmentMessage['PinPosition'])){
+			foreach ($this->shipmentMessage['PinPosition'] as $existing){
+				if($existing['positionInPin']===$pinPosition && $existing['containerRef']['$ref']==='#/MultiPin/MultiPin'.$pinIndex){
+					throw new \Exception('Pin position is already filled');
+				}
+			}
+		}
+		if(isset($this->shipmentMessage['MacromoleculeSample'])){
+			foreach ($this->shipmentMessage['MacromoleculeSample'] as $existing){
+				if($existing['name']===$sampleName){
+					throw new \Exception('Sample name already exists in shipment');
+				}
+			}
+		}
+		$sample=$this->getBaseObject('MacromoleculeSample', $sampleUuid);
+		$sample['macromoleculeRef']=['$ref'=>'#/Macromolecule/Macromolecule'.$macromoleculeIndex];
+		$sample['name']=$sampleName;
+		$this->setObjectToMessage($sample);
+		$position=$this->getBaseObject('PinPosition');
+		$position['containerRef']=['$ref'=>'#/MultiPin/MultiPin'.$pinIndex];
+		$position['sampleRef']=['$ref'=>'#/MacromoleculeSample/MacromoleculeSample'.$sample['index']];
+		$position['positionInPin']=$pinPosition;
+		$this->setObjectToMessage($position);
+		return [
+			'MacromoleculeSample'=>$sample,
+			'PinPosition'=>$position
+		];
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::addPlateToShipment()
+	 * @throws \Exception
+	 */
+	public function addPlateToShipment(string $barcode, int $rows, int $columns, int $subPositions, ?string $dropMapping=null, ?string $uuid = null): array {
+		if(!isset($this->shipmentMessage['Shipment'])){
+			throw new \Exception("Call createShipment() before addPlateToShipment()");
+		}
+		if(array_key_exists("Dewar", $this->shipmentMessage)){
+			throw new \Exception("Shipment contains Dewars, cannot add Plate");
+		}
+		if(empty($barcode)){ throw new \Exception("Barcode cannot be empty"); }
+		if(isset($this->shipmentMessage['Plate'])){
+			foreach ($this->shipmentMessage['Plate'] as $existing) {
+				if($existing['barcode']===$barcode){
+					throw new \Exception("Plate with barcode $barcode already in shipment");
+				}
+			}
+		}
+		if($rows<1){ throw new \Exception("Rows must be a positive number"); }
+		if($columns<1){ throw new \Exception("Columns must be a positive number"); }
+		if($subPositions<1){ throw new \Exception("Sub positions must be a positive number"); }
+		if(empty($dropMapping)){
+			//Default drop mapping - sub-wells across the top in numerical order, reservoir below
+			$part1='';
+			$part2='';
+			for($i=1;$i<=$subPositions;$i++){
+				$part1.=$i;
+				$part2.='R';
+			}
+			$dropMapping=$part1.','.$part2;
+		}
+		if(!preg_match('/^[\dR,]+$/',$dropMapping)){ throw new \Exception("Mapping is not valid"); }
+		$plate=$this->getBaseObject('Plate', $uuid);
+		$plate['barcode']=$barcode;
+		$plate['containerRef']=['$ref'=>'#/Shipment/Shipment1'];
+		$plate['plateType']=[
+			'numberRows'=>$rows,
+			'numberColumns'=>$columns,
+			'numberSubPositions'=>$subPositions,
+			'dropMapping'=>$dropMapping
+		];
+		$this->setObjectToMessage($plate);
+		return $plate;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::addWellToPlate()
+	 * @throws \Exception
+	 */
+	public function addWellToPlate(int $plateIndex, int $rowNumber, int $columnNumber, ?string $uuid=null): array {
+		$plate=$this->get('Plate',$plateIndex);
+		if(!$plate){
+			throw new \Exception('No plate with index '.$plateIndex);
+		}
+		if($rowNumber<1 || $rowNumber>$plate['plateType']['numberRows']){
+			throw new \Exception('Row number must be between 1 and '.$plate['plateType']['numberRows']);
+		}
+		if($columnNumber<1 || $columnNumber>$plate['plateType']['numberColumns']){
+			throw new \Exception('Column number must be between 1 and '.$plate['plateType']['numberColumns']);
+		}
+		if(isset($this->shipmentMessage['PlateWell'])){
+			foreach ($this->shipmentMessage['PlateWell'] as $existing){
+				if($existing['rowNumber']===$rowNumber && $existing['columnNumber']===$columnNumber && $existing['containerRef']['$ref']==='#/Plate/Plate'.$plateIndex){
+					throw new \Exception('Well already exists');
+				}
+			}
+		}
+		$well=$this->getBaseObject('PlateWell', $uuid);
+		$well['rowNumber']=$rowNumber;
+		$well['columnNumber']=$columnNumber;
+		$well['containerRef']=['$ref'=>'#/Plate/Plate'.$plateIndex];
+		$this->setObjectToMessage($well);
+		return $well;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::addDropToPlateWell()
+	 * @throws \Exception
+	 */
+	public function addDropToPlateWell(int $wellIndex, int $dropNumber, int $macromoleculeIndex, ?string $name=null, ?string $uuid=null): array {
+		$well=$this->get('PlateWell',$wellIndex);
+		$macromolecule=$this->get('Macromolecule',$macromoleculeIndex);
+		if(!$well){
+			throw new \Exception('No well with index '.$wellIndex);
+		}
+		if(!$macromolecule){
+			throw new \Exception('No macromolecule with index '.$macromoleculeIndex);
+		}
+		$plateIndex=preg_replace('/\D/', '', $well['containerRef']['$ref']);
+		$plate=$this->get('Plate', (int)$plateIndex);
+		if(!$plate){
+				//Safety, shouldn't be possible
+				throw new \Exception('No plate with index '.$plateIndex);
+		}
+		if($dropNumber<1 || $dropNumber>$plate['plateType']['numberSubPositions']){
+			throw new \Exception('Drop number must be between 1 and '.$plate['plateType']['numberSubPositions']);
+		}
+		if(isset($this->shipmentMessage['WellDrop'])){
+			foreach($this->shipmentMessage['WellDrop'] as $existing){
+				if($dropNumber==$existing['dropNumber'] && $existing['containerRef']['$ref']==='#/PlateWell/PlateWell'.$wellIndex){
+					throw new \Exception('This well drop already exists');
+				}
+				if($existing['name']===$name){
+					throw new \Exception('A well drop with this name already exists');
+				}
+			}
+		}
+		if(!$name){
+			$name=$plate['barcode'].'_'.$this->plateRowLabels[$well['rowNumber']].str_pad("".$well['columnNumber'], 2, '0',STR_PAD_LEFT).'_'.$dropNumber;
+		}
+		$sample=self::getBaseObject('MacromoleculeSample', $uuid);
+		$sample['name']=$name;
+		$sample['macromoleculeRef']=['$ref'=>'#/Macromolecule/Macromolecule'.$macromoleculeIndex];
+		$this->setObjectToMessage($sample);
+		$drop=self::getBaseObject('WellDrop');
+		$drop['name']=$name;
+		$drop['dropNumber']=$dropNumber;
+		$drop['containerRef']=['$ref'=>'#/PlateWell/PlateWell'.$wellIndex];
+		$drop['sampleRef']=['$ref'=>'#/MacromoleculeSample/MacromoleculeSample'.$sample['index']];
+		$this->setObjectToMessage($drop);
+		return [
+			'WellDrop'=>$drop,
+			'MacromoleculeSample'=>$sample
+		];
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::getPlateWellByPosition()
+	 * @throws \Exception
+	 */
+	public function getPlateWellByPosition(int $plateIndex, int $rowNumber, int $columnNumber): ?array {
+		if(!isset($this->shipmentMessage['Plate']['Plate'.$plateIndex])){
+			throw new \Exception('No plate with index '.$plateIndex);
+		}
+		$foundWell=null;
+		if(!isset($this->shipmentMessage['PlateWell'])){ return null; }
+		$plateRef='#/Plate/Plate'.$plateIndex;
+		foreach ($this->shipmentMessage['PlateWell'] as $well) {
+			if ($plateRef === $well['containerRef']['ref'] && $rowNumber === $well['rowNumber'] && $columnNumber === $well['columnNumber']) {
+				$foundWell = $well;
+				break;
+			}
+		}
+		return $foundWell;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::getWellDropByPosition()
+	 * @throws \Exception
+	 */
+	public function getWellDropByPosition(int $plateIndex, int $rowNumber, int $columnNumber, int $dropNumber): ?array {
+		$well=$this->getPlateWellByPosition($plateIndex, $rowNumber, $dropNumber);
+		if(!$well){ return null; }
+		$foundDrop=null;
+		if(!isset($this->shipmentMessage['WellDrop'])) { return null; }
+		$wellRef = '#/PlateWell/PlateWell' . $well['index'];
+		foreach ($this->shipmentMessage['WellDrop'] as $drop) {
+			if ($wellRef === $drop['containerRef']['$ref'] && $dropNumber === $drop['dropNumber']) {
+				$foundDrop = $drop;
+				break;
+			}
+		}
+		return $foundDrop;
+	}
+
+
+	/**
+	 * Adds a drop region.
+	 *
+	 * For plate regions: Leave $imageMimeType, $imageUrl and $imageData null. Co-ordinate units are assumed to be microns.
+	 *
+	 * For image regions. Specify $imageMimeType AND ($imageUrl XOR $imageData). Co-ordinate units are assumed to be pixels.
+	 *
+	 * @param int $dropIndex The index of the drop itself
+	 * @param array $region
+	 * @param string|null $imageMimeType The image mime-type. Must be present if $imageUrl or $imageData specified.
+	 * @param string|null $imageUrl
+	 * @param string|null $imageData
+	 * @return array
+	 * @throws \Exception
+	 */
+	private function addDropRegion(int $dropIndex, array $region, ?string $imageMimeType=null, ?string $imageUrl=null, ?string $imageData=null): array {
+		if(!empty($imageUrl) && !empty($imageData)) {
+			throw new \Exception('Cannot specify both imageUrl and imageData; leave both empty for plate coordinates in microns');
+		} else if(!empty($imageUrl) || !empty($imageData)){
+			if(!empty($imageUrl) && false===filter_var($imageUrl, FILTER_VALIDATE_URL)){
+				throw new \Exception('Bad image URL '.$imageUrl);
+			}
+			if(empty($imageMimeType)){
+				throw new \Exception('No image MIME type set');
+			} else if(!str_starts_with($imageMimeType, 'image/')){
+				throw new \Exception('Bad image MIME type');
+			}
+		} else if(!empty($imageMimeType)) {
+			throw new \Exception('Do not set image MIME type for plate co-ordinates');
+		}
+		$dropRegion=$this->getBaseObject('DropRegion');
+		$dropRegion['containerRef']=['$ref'=>'#/WellDrop/WellDrop'.$dropIndex];
+		$dropRegion['region']=[
+			'region'=>$region
+		];
+		if(!empty($imageUrl)){
+			$dropRegion['region']['units']='pixel';
+			$dropRegion['region']['image']=[
+				'mimeType'=>$imageMimeType,
+				'image'=>$imageUrl
+			];
+		} else if(!empty($imageData)){
+			$dropRegion['region']['units']='pixel';
+			$dropRegion['region']['image']=[
+				'mimeType'=>$imageMimeType,
+				'data'=>$imageData
+			];
+		} else {
+			//Assumed plate coordinate
+			$dropRegion['region']['units']='micron';
+		}
+		$this->setObjectToMessage($dropRegion);
+		return $dropRegion;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::addPointDropRegionByPlateDropIndex()
+	 * @throws \Exception
+	 */
+	public function addPointDropRegionByPlateDropIndex(int $dropIndex, int $x, int $y, ?string $imageMimeType=null, ?string $imageUrl=null, ?string $imageData=null): array {
+		if($x<0 || $y<0){ throw new \Exception('x and y cannot be negative'); }
+		$point=[
+			'regionType'=>'point',
+			'x'=>$x,
+			'y'=>$y
+		];
+		return $this->addDropRegion($dropIndex, $point, $imageMimeType, $imageUrl, $imageData);
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::addCrystalToDropRegion()
+	 * @throws \Exception
+	 */
+	public function addCrystalToDropRegion(int $dropRegionIndex, string $name, ?string $uuid=null): array {
+		$dropRegion=$this->get('DropRegion', $dropRegionIndex);
+		if(!$dropRegion){ throw new \Exception('No DropRegion with index '.$dropRegionIndex); }
+		$crystal=$this->getBaseObject('Crystal', $uuid);
+		$crystal['name']=$name;
+		$wellDrop=$this->getByJsonPath($dropRegion['containerRef']);
+		$crystal['sampleRef']=$wellDrop['sampleRef'];
+		$crystal['containerRef']=['$ref'=>'#/DropRegion/DropRegion'.$dropRegion['index']];
+		$this->setObjectToMessage($crystal);
+		return $crystal;
+	}
+
+
+	/**
+	 * Checks that all parent objects are referred to by a child (for example, that all Dewars contain at least one Puck).
+	 * Assumes that only one key in the child object will refer to the parent.
+	 * @param string $parentType The parent type.
+	 * @param string $childType The child type.
+	 * @return void if all parents are referred to by at least one child.
+	 * @throws \Exception if none of the parent type are present.
+	 * @throws \Exception if none of the child type are present.
+	 * @throws \Exception if any parent is not referred to by at least one child.
+	 */
+	private function validateAllParentsHaveChild(string $parentType, string $childType): void {
+		if(!isset($this->shipmentMessage[$parentType])){ throw new \Exception("No {$parentType}s in the shipment"); }
+		if(!isset($this->shipmentMessage[$childType])){ throw new \Exception("No {$childType}s in the shipment"); }
+		if(!isset($this->shipmentMessage[$childType][$childType.'1'])){ throw new \Exception("No {$childType}1 in the shipment"); }
+		$parentKeys=[];
+		$referenceKey='';
+		foreach ($this->shipmentMessage[$childType][$childType.'1'] as $k=>$v) {
+			if(isset($v['$ref'])){
+				$parts=explode('/', $v['$ref']);
+				if($parts[1]===$parentType) {
+					$referenceKey = $k;
+					break;
+				}
+			}
+		}
+		if(''===$referenceKey) { throw new \Exception("Cannot determine child property that refers to $parentType in $childType"); }
+
+		foreach ($this->shipmentMessage[$childType] as $child) {
+			$parentKey=(explode('/', $child[$referenceKey]['$ref']))[2]; // "#/Dewar/Dewar1"
+			$parentKeys[]=$parentKey;
+		}
+		$parentKeys=array_unique($parentKeys);
+		foreach(array_keys($this->shipmentMessage[$parentType]) as $toCheck){
+			if(!in_array($toCheck, $parentKeys)){
+				throw new \Exception("$toCheck is not referred to by any $childType");
+			}
+			if(count($parentKeys)!==count($this->shipmentMessage[$parentType])){
+				throw new \Exception("Count mismatch - number of {$parentType}s does not match number of {$parentType}s referred to by {$childType}s");
+			}
+		}
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::validate()
+	 * @throws \Exception
+	 */
+	public function validate(): bool {
+		$shipment=$this->get('Shipment',1);
+		$dewar1=$this->get('Dewar',1);
+		$plate1=$this->get('Plate',1);
+		$macromolecule1=$this->get('Macromolecule',1);
+		if(!$shipment){ throw new \Exception("No shipment"); }
+		if(!isset($shipment['labContactOutbound'])){ throw new \Exception("No outbound lab contact"); }
+		if(!isset($shipment['labContactReturn'])){ throw new \Exception("No return lab contact"); }
+		if(!$dewar1 && !$plate1){ throw new \Exception("No Dewars or Plates in the shipment"); }
+		if(!$macromolecule1){ throw new \Exception("No Macromolecules in the shipment"); }
+
+		if($dewar1){
+			$this->validateAllParentsHaveChild('Dewar','Puck');
+			$this->validateAllParentsHaveChild('Shipment','Dewar');
+			if(isset($this->shipmentMessage['Pin'])){
+				$this->validateAllParentsHaveChild('Puck','Pin');
+				$this->validateAllParentsHaveChild('MacromoleculeSample','Pin');
+				$this->validateAllParentsHaveChild('Macromolecule','MacromoleculeSample');
+			} else if(isset($this->shipmentMessage['MultiPin'])){
+				$this->validateAllParentsHaveChild('Puck','MultiPin');
+				$this->validateAllParentsHaveChild('MultiPin','PinPosition');
+				$this->validateAllParentsHaveChild('MacromoleculeSample','PinPosition');
+			} else {
+				throw new \Exception("No Pins or MultiPins in the shipment");
+			}
+		} else {
+			$this->validateAllParentsHaveChild('Plate','PlateWell');
+			$this->validateAllParentsHaveChild('PlateWell','WellDrop');
+			$this->validateAllParentsHaveChild('WellDrop','DropRegion');
+
+		}
+
+		if(isset($this->shipmentMessage['Dewar'])){
+			if(isset($this->shipmentMessage['Pin'])){
+				if(!isset($this->shipmentMessage['MacromoleculeSample'])){
+					throw new \Exception("No samples in the shipment");
+				}
+			} else if(isset($this->shipmentMessage['MultiPin'])){
+				if(!isset($this->shipmentMessage['MacromoleculeSample'])){
+					throw new \Exception("No samples in the shipment");
+				}
+			} else {
+				throw new \Exception("No pins in the shipment");
+			}
+		} else if(isset($this->shipmentMessage['Plate'])){
+			if(!isset($this->shipmentMessage['Crystal'])){
+				throw new \Exception("No crystal in the shipment");
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * @see ShipmentEncoderInterface::validate()
+	 * @throws \Exception
+	 */
+	public function encodeToJSON(bool $prettyPrint=false): string {
+		$this->validate();
+		$flags=null;
+		if($prettyPrint){
+			$flags=JSON_PRETTY_PRINT;
+		}
+		return json_encode($this->shipmentMessage, $flags);
+	}
+
+}
+

--- a/mxlims/tools/php/ShipmentEncoder/src/v0_6_5ShipmentEncoder.php
+++ b/mxlims/tools/php/ShipmentEncoder/src/v0_6_5ShipmentEncoder.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace mxlims\tools\php\ShipmentEncoder\src;
+
+include_once __DIR__.'/ShipmentEncoderInterface.php';
+include_once __DIR__.'/v0_6_4ShipmentEncoder.php';
+
+class v0_6_5ShipmentEncoder extends v0_6_4ShipmentEncoder {
+
+	//Overwrite any 0.6.4 methods here
+
+}
+

--- a/mxlims/tools/php/ShipmentEncoder/test/SchemaValidationCommand.example
+++ b/mxlims/tools/php/ShipmentEncoder/test/SchemaValidationCommand.example
@@ -1,6 +1,11 @@
 Create a file in this directory called SchemaValidationCommand. This should
 contain only the command to validate a JSON file against a schema on your
-system. The following line is how I (Ed Daniel) do it in PowerShell.
+system; the PHPUnit tests will run this command to ensure that the JSON being
+output by the shipment encoder will validate against the schema.
+
+The following line is how I (Ed Daniel) do it in PowerShell. Note that the
+{{$schemaFile}} and {{$jsonFile}} parts must appear exactly as shown, as
+they will be replaced with the correct values by the PHPUnit tests.
 
 "C:\Program Files\PowerShell\7\pwsh.exe" -command  Test-Json -SchemaFile {{$schemaFile}} -Path {{$jsonFile}}
 

--- a/mxlims/tools/php/ShipmentEncoder/test/SchemaValidationCommand.example
+++ b/mxlims/tools/php/ShipmentEncoder/test/SchemaValidationCommand.example
@@ -1,0 +1,6 @@
+Create a file in this directory called SchemaValidationCommand. This should
+contain only the command to validate a JSON file against a schema on your
+system. The following line is how I (Ed Daniel) do it in PowerShell.
+
+"C:\Program Files\PowerShell\7\pwsh.exe" -command  Test-Json -SchemaFile {{$schemaFile}} -Path {{$jsonFile}}
+

--- a/mxlims/tools/php/ShipmentEncoder/test/v0_6_4ShipmentEncoderTest.php
+++ b/mxlims/tools/php/ShipmentEncoder/test/v0_6_4ShipmentEncoderTest.php
@@ -1,0 +1,863 @@
+<?php
+
+namespace mxlims\tools\php\ShipmentEncoder\test;
+
+use PHPUnit\Framework\TestCase;
+
+class v0_6_4ShipmentEncoderTest extends TestCase {
+
+	public function setUp(): void {
+		if(!$this->version ||!$this->encoder){
+			$parts = explode('\\', get_called_class());
+			$className = end($parts);
+			$className = str_replace('Test', '', $className);
+			if (!preg_match('/\d+_\d+_\d+/', $className, $matches)) {
+				die('Cannot determine version from class name');
+			}
+			$version = str_replace('_', '.', $matches[0]);
+			$this->version = $version;
+			include_once '../src/' . $className . '.php';
+			$fullClassName = 'mxlims\tools\php\ShipmentEncoder\src\\' . $className;
+			$this->encoder = new $fullClassName();
+		}
+	}
+
+	public function tearDown(): void {
+		unset($this->encoder);
+		@unlink(__DIR__.'/test.json');
+	}
+
+	public function testGetVersion() {
+		$version = $this->encoder->getVersion();
+		$this->assertEquals($this->version, $version);
+	}
+
+	public function testGet() {
+		$this->encoder->createShipment('mx4025', 1);
+		$shipment = $this->encoder->get('Shipment', 1);
+		self::assertNotEmpty($shipment);
+		self::assertEquals('Shipment', $shipment['mxlimsType']);
+		self::assertEquals(1, $shipment['index']);
+	}
+
+	public function testGetByJsonPath() {
+		$this->encoder->createShipment('mx4025', 1);
+		$shipment=$this->encoder->getByJsonPath('#/Shipment/Shipment1');
+		self::assertNotEmpty($shipment);
+		self::assertEquals('Shipment', $shipment['mxlimsType']);
+		self::assertEquals(1, $shipment['index']);
+	}
+
+	public function testGetByJsonPathWithRef() {
+		$this->encoder->createShipment('mx4025', 1);
+		$shipment=$this->encoder->getByJsonPath(['$ref'=>'#/Shipment/Shipment1']);
+		self::assertNotEmpty($shipment);
+		self::assertEquals('Shipment', $shipment['mxlimsType']);
+		self::assertEquals(1, $shipment['index']);
+	}
+
+	public function testGetNonExistent() {
+		$shipment = $this->encoder->get('Shipment', 1);
+		self::assertNull($shipment);
+	}
+
+	public function testCreateShipment() {
+		$shipment = $this->encoder->createShipment('mx4025', 1);
+		$this->assertEquals('mx4025', $shipment['proposalCode']);
+		$this->assertEquals(1, $shipment['sessionNumber']);
+		$this->assertEquals('Shipment', $shipment['mxlimsType']);
+		$this->assertEquals($this->version, $shipment['version']);
+		$this->assertNotEmpty($shipment['uuid']);
+		$this->assertEquals(1, $shipment['index']);
+	}
+
+	public function testCreateShipmentNoSessionNumber() {
+		$shipment = $this->encoder->createShipment('mx4025');
+		$this->assertEquals('mx4025', $shipment['proposalCode']);
+		$this->assertArrayNotHasKey('sessionNumber', $shipment);
+		$this->assertEquals('Shipment', $shipment['mxlimsType']);
+		$this->assertEquals($this->version, $shipment['version']);
+		$this->assertNotEmpty($shipment['uuid']);
+	}
+
+	public function testCreateShipmentTwice() {
+		$this->expectExceptionMessageMatches('~Shipment already added to message~');
+		$this->encoder->createShipment('mx4025', 1);
+		$this->encoder->createShipment('mx4025', 1);
+	}
+
+	public function testSetLabContactOutbound() {
+		$labContact = $this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->assertEquals('Bob', $labContact['name']);
+		$this->assertEquals('bob@bob.com', $labContact['emailAddress']);
+		$this->assertArrayNotHasKey('phoneNumber', $labContact);
+	}
+
+	public function testSetLabContactReturn() {
+		$labContact = $this->encoder->setLabContactReturn('Bob', 'bob@bob.com');
+		$this->assertEquals('Bob', $labContact['name']);
+		$this->assertEquals('bob@bob.com', $labContact['emailAddress']);
+		$this->assertArrayNotHasKey('phoneNumber', $labContact);
+	}
+
+	public function testSetLabContactReturnBothContactDetails() {
+		$labContact = $this->encoder->setLabContactReturn('Bob', 'bob@bob.com', '1-800-BOB-1234');
+		$this->assertEquals('Bob', $labContact['name']);
+		$this->assertEquals('bob@bob.com', $labContact['emailAddress']);
+		$this->assertEquals('1-800-BOB-1234', $labContact['phoneNumber']);
+	}
+
+	public function testSetLabContactReturnNoContactDetails() {
+		$this->expectExceptionMessageMatches('~Email or phone number~');
+		$this->encoder->setLabContactReturn('Bob');
+	}
+
+	public function testAddDewarToShipment() {
+		$this->encoder->createShipment('mx4025', 1);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$this->assertEquals('DLS-MX-1234', $dewar['barcode']);
+		$this->assertEquals('Dewar', $dewar['mxlimsType']);
+		$this->assertArrayHasKey('uuid', $dewar);
+		$this->assertEquals(1, $dewar['index']);
+	}
+
+	public function testAddDewarToShipmentNoShipment() {
+		$this->expectExceptionMessageMatches('~Call createShipment~');
+		$this->encoder->addDewarToShipment('DLS-MX-1234');
+	}
+
+	public function testAddDewarToShipmentPlateExists() {
+		$this->expectExceptionMessageMatches('~Shipment contains Plates~');
+		$this->encoder->createShipment('mx4025', 1);
+		$this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$this->encoder->addDewarToShipment('DLS-MX-1234');
+
+	}
+
+	public function testAddPuckToDewar() {
+		$this->encoder->createShipment('mx4025', 1);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->assertEquals('OUL-999', $puck['barcode']);
+		$this->assertEquals('Puck', $puck['mxlimsType']);
+		$this->assertArrayHasKey('uuid', $puck);
+		$this->assertEquals(1, $puck['index']);
+	}
+
+	public function testAddPuckToDewarNoDewar() {
+		$this->expectExceptionMessageMatches('~No dewar with index~');
+		$this->encoder->createShipment('mx4025', 1);
+		$this->encoder->addPuckToDewar(1, 'OUL-999', 16);
+	}
+
+	public function testAddMacromoleculeToShipment() {
+		$this->encoder->createShipment('mx4025', 1);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$this->assertEquals(1, $macromolecule['index']);
+		$this->assertEquals('TEST', $macromolecule['acronym']);
+		$this->assertEquals('Macromolecule', $macromolecule['mxlimsType']);
+		$this->assertNotEmpty($macromolecule['uuid']);
+	}
+
+	public function testAddMacromoleculeToShipmentNoAcronym() {
+		$this->encoder->createShipment('mx4025', 1);
+		$this->expectExceptionMessageMatches('~cannot be empty~');
+		$this->encoder->addMacromoleculeToShipment('');
+	}
+
+	public function testAddSinglePinSampleToPuck() {
+		$this->encoder->createShipment('mx4025', 1);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$pinAndSample = $this->encoder->addSinglePinSampleToPuck($puck['index'], 1, $macromolecule['index'], 'TEST_9098A01d1c1', 'HA00AA5432');
+		$this->assertArrayHasKey('Pin', $pinAndSample);
+		$this->assertArrayHasKey('MacromoleculeSample', $pinAndSample);
+		$pin = $pinAndSample['Pin'];
+		$this->assertEquals('HA00AA5432', $pin['barcode']);
+		$this->assertEquals('#/Puck/Puck' . $puck['index'], $pin['containerRef']['$ref']);
+		$this->assertEquals('#/MacromoleculeSample/MacromoleculeSample' . $pin['index'], $pin['sampleRef']['$ref']);
+		$this->assertNotEmpty($pin['uuid']);
+		$sample = $pinAndSample['MacromoleculeSample'];
+		$this->assertEquals('TEST_9098A01d1c1', $sample['name']);
+		$this->assertNotEmpty($sample['uuid']);
+	}
+
+	public function testAddSinglePinSampleToPuckMultiPinExists() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$this->encoder->addMultiPositionPinToPuck($puck['index'], 4, 8, 'PIN1');
+		$this->expectExceptionMessageMatches('~Cannot mix multi-position pins~');
+		$this->encoder->addSinglePinSampleToPuck(2, 1, $macromolecule['index'], 'TEST_9098A01d1c1', 'HA00AA5432');
+	}
+
+	public function testAddSinglePinSampleToPuckBadPuckIndex() {
+		$this->encoder->createShipment('mx4025', 11);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->expectExceptionMessageMatches('~No puck with index~');
+		$this->encoder->addSinglePinSampleToPuck(2, 1, $macromolecule['index'], 'TEST_9098A01d1c1', 'HA00AA5432');
+	}
+
+	public function testAddSinglePinSampleToPuckBadMacromoleculeIndex() {
+		$this->encoder->createShipment('mx4025', 1);
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->expectExceptionMessageMatches('~No macromolecule with index~');
+		$this->encoder->addSinglePinSampleToPuck($puck['index'], 1, 2, 'TEST_9098A01d1c1', 'HA00AA5432');
+	}
+
+	public function testAddSinglePinSampleToPuckPositionOutOfRange() {
+		$this->encoder->createShipment('mx4025', 1);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->expectExceptionMessageMatches('~Puck position must be between~');
+		$this->encoder->addSinglePinSampleToPuck($puck['index'], 17, $macromolecule['index'], 'TEST_9098A01d1c1', 'HA00AA5432');
+	}
+
+	public function testAddSinglePinSampleToPuckPositionFull() {
+		$this->encoder->createShipment('mx4025', 1);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->expectExceptionMessageMatches('~already filled~');
+		$this->encoder->addSinglePinSampleToPuck($puck['index'], 4, $macromolecule['index'], 'TEST_9098A01d1c1', 'HA00AA5432');
+		$this->encoder->addSinglePinSampleToPuck($puck['index'], 4, $macromolecule['index'], 'TEST_9098A01d1c2', 'HA00AA5434');
+	}
+
+	public function testAddSinglePinSampleToPuckDuplicateBarcode() {
+		$this->encoder->createShipment('mx4025', 2);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->encoder->addSinglePinSampleToPuck($puck['index'], 4, $macromolecule['index'], 'TEST_9098A01d1c1', 'HA00AA5432');
+		$this->expectExceptionMessageMatches('~Shipment already contains a pin with barcode~');
+		$this->encoder->addSinglePinSampleToPuck($puck['index'], 5, $macromolecule['index'], 'TEST_9098A01d1c2', 'HA00AA5432');
+	}
+
+	public function testAddMultiPositionPinToPuck() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$pin = $this->encoder->addMultiPositionPinToPuck($puck['index'], 4, 8, 'MULTIPIN1');
+		$this->assertEquals('MULTIPIN1', $pin['barcode']);
+		$this->assertEquals('#/Puck/Puck' . $puck['index'], $pin['containerRef']['$ref']);
+		$this->assertEquals(4, $pin['positionInPuck']);
+		$this->assertEquals(8, $pin['numberPositions']);
+		$this->assertEquals(1, $pin['index']);
+	}
+
+	public function testAddMultiPositionPinToPuckSinglePositionPinExists() {
+		$this->encoder->createShipment('mx4025', 4);
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->encoder->addSinglePinSampleToPuck($puck['index'], 1, 1, 'TEST_9098A01d1c1', 'HA00AA5432');
+		$this->expectExceptionMessageMatches('~contains single-position pin~');
+		$this->encoder->addMultiPositionPinToPuck($puck['index'], 4, 8, 'MULTIPIN1');
+	}
+
+	public function testAddMultiPositionPinNoPuck() {
+		$this->expectExceptionMessageMatches('~No puck with index~');
+		$this->encoder->addMultiPositionPinToPuck(1, 4, 8, 'MULTIPIN1');
+	}
+
+	public function testAddMultiPositionPinBadPositionCount() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->expectExceptionMessageMatches('~positions must be a positive integer~');
+		$this->encoder->addMultiPositionPinToPuck($puck['index'], 4, 0, 'MULTIPIN1');
+	}
+
+	public function testAddMultiPositionPinBadPuckPosition() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->expectExceptionMessageMatches('~Position in puck must be between~');
+		$this->encoder->addMultiPositionPinToPuck($puck['index'], 17, 8, 'MULTIPIN1');
+	}
+
+	public function testAddMultiPositionPinPuckPositionFull() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->encoder->addMultiPositionPinToPuck($puck['index'], 10, 8, 'MULTIPIN1');
+		$this->expectExceptionMessageMatches('~already filled~');
+		$this->encoder->addMultiPositionPinToPuck($puck['index'], 10, 8, 'MULTIPIN1');
+	}
+
+	public function testAddSinglePinSampleToPuckDuplicateSampleName() {
+		$this->encoder->createShipment('mx4025', 3);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->encoder->addSinglePinSampleToPuck($puck['index'], 4, $macromolecule['index'], 'TEST_9098A01d1c1', 'HA00AA5432');
+		$this->expectExceptionMessageMatches('~Shipment already contains a sample with name~');
+		$this->encoder->addSinglePinSampleToPuck($puck['index'], 5, $macromolecule['index'], 'TEST_9098A01d1c1', 'HA00AA5434');
+	}
+
+	public function testAddSinglePositionPinToPuck() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$pin = $this->encoder->addSinglePositionPinToPuck($puck['index'], 4, 'MULTIPIN1');
+		$this->assertEquals('MULTIPIN1', $pin['barcode']);
+		$this->assertEquals('#/Puck/Puck' . $puck['index'], $pin['containerRef']['$ref']);
+		$this->assertEquals(4, $pin['positionInPuck']);
+		$this->assertEquals(1, $pin['index']);
+	}
+
+	public function testAddSinglePositionPinToPuckMultiPositionPinExists() {
+		$this->encoder->createShipment('mx4025', 4);
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->encoder->addMultiPositionPinToPuck($puck['index'], 4, 8, 'MULTIPIN1');
+		$this->expectExceptionMessageMatches('~contains multi-position pin~');
+		$this->encoder->addSinglePositionPinToPuck($puck['index'], 1, 'HA00AA5432');
+	}
+
+	public function testAddSinglePositionPinNoPuck() {
+		$this->expectExceptionMessageMatches('~No puck with index~');
+		$this->encoder->addSinglePositionPinToPuck(1, 4, 'MULTIPIN1');
+	}
+
+	public function testAddSinglePositionPinBadPuckPosition() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->expectExceptionMessageMatches('~Position in puck must be between~');
+		$this->encoder->addSinglePositionPinToPuck($puck['index'], 17, 'PIN1');
+	}
+
+	public function testAddSinglePositionPinPuckPositionFull() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->encoder->addSinglePositionPinToPuck($puck['index'], 10, 'PIN1');
+		$this->expectExceptionMessageMatches('~already filled~');
+		$this->encoder->addSinglePositionPinToPuck($puck['index'], 10, 'MULTIPIN1');
+	}
+
+	public function testAddSampleToMultiPositionPin() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$pin = $this->encoder->addMultiPositionPinToPuck($puck['index'], 10, 8, 'MULTIPIN1');
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$ret = $this->encoder->addSampleToMultiPositionPin($pin['index'], 1, $macromolecule['index'], 'TEST_9098A01d1c1');
+		$this->assertArrayHasKey('MacromoleculeSample', $ret);
+		$this->assertEquals('TEST_9098A01d1c1', $ret['MacromoleculeSample']['name']);
+		$this->assertEquals('#/Macromolecule/Macromolecule' . $macromolecule['index'], $ret['MacromoleculeSample']['macromoleculeRef']['$ref']);
+		$this->assertArrayHasKey('PinPosition', $ret);
+		$this->assertEquals(1, $ret['PinPosition']['positionInPin']);
+		$this->assertEquals('#/MacromoleculeSample/MacromoleculeSample' . $ret['MacromoleculeSample']['index'], $ret['PinPosition']['sampleRef']['$ref']);
+		$this->assertEquals('#/MultiPin/MultiPin' . $pin['index'], $ret['PinPosition']['containerRef']['$ref']);
+	}
+
+	public function testAddSampleToMultiPositionPinNoPin() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$this->expectExceptionMessageMatches('~No pin~');
+		$this->encoder->addSampleToMultiPositionPin(1, 1, $macromolecule['index'], 'TEST_9098A01d1c1');
+	}
+
+	public function testAddSampleToMultiPositionPinNoMacromolecule() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$pin = $this->encoder->addMultiPositionPinToPuck($puck['index'], 10, 8, 'MULTIPIN1');
+		$this->expectExceptionMessageMatches('~No macromolecule~');
+		$this->encoder->addSampleToMultiPositionPin($pin['index'], 1, 1, 'TEST_9098A01d1c1');
+	}
+
+	public function testAddSampleToMultiPositionPinPositionFull() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$pin = $this->encoder->addMultiPositionPinToPuck($puck['index'], 10, 8, 'MULTIPIN1');
+		$this->encoder->addSampleToMultiPositionPin($pin['index'], 1, $macromolecule['index'], 'TEST_9098A01d1c1');
+		$this->expectExceptionMessageMatches('~already filled~');
+		$this->encoder->addSampleToMultiPositionPin($pin['index'], 1, $macromolecule['index'], 'TEST_9098A01d1c2');
+	}
+
+	public function testAddSampleToMultiPositionPinDuplicateSampleName() {
+		$this->encoder->createShipment('mx4025', 4);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$pin = $this->encoder->addMultiPositionPinToPuck($puck['index'], 10, 8, 'MULTIPIN1');
+		$this->encoder->addSampleToMultiPositionPin($pin['index'], 1, $macromolecule['index'], 'TEST_9098A01d1c1');
+		$this->expectExceptionMessageMatches('~name already exists~');
+		$this->encoder->addSampleToMultiPositionPin($pin['index'], 2, $macromolecule['index'], 'TEST_9098A01d1c1');
+	}
+
+	public function testAddPlateToShipment() {
+		$this->encoder->createShipment('mx4025', 1);
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$this->assertEquals('BARCODE1234', $plate['barcode']);
+		$this->assertEquals('Plate', $plate['mxlimsType']);
+		$this->assertArrayHasKey('uuid', $plate);
+		$this->assertEquals(1, $plate['index']);
+		$this->assertArrayHasKey('plateType', $plate);
+		$this->assertEquals(8, $plate['plateType']['numberRows']);
+		$this->assertEquals(12, $plate['plateType']['numberColumns']);
+		$this->assertEquals(3, $plate['plateType']['numberSubPositions']);
+		$this->assertEquals('123,RRR', $plate['plateType']['dropMapping']);
+	}
+
+	public function testAddPlateToShipmentNoShipment() {
+		$this->expectExceptionMessageMatches('~Call createShipment~');
+		$this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+	}
+
+	public function testAddPlateToShipmentDewarExists() {
+		$this->expectExceptionMessageMatches('~Shipment contains Dewars~');
+		$this->encoder->createShipment('mx4025', 1);
+		$this->encoder->addDewarToShipment('DLS-MX-1234');
+		$this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+	}
+
+	public function testAddPlateToShipmentTwice() {
+		$this->expectExceptionMessageMatches('~already in shipment~');
+		$this->encoder->createShipment('mx4025', 1);
+		$this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+	}
+
+	public function testAddWellToPlate() {
+		$this->encoder->createShipment('mx4025', 1);
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$well = $this->encoder->addWellToPlate($plate['index'], 4, 5);
+		$this->assertEquals(4, $well['rowNumber']);
+		$this->assertEquals(5, $well['columnNumber']);
+	}
+
+	public function testAddWellToPlateNoPlate() {
+		$this->encoder->createShipment('mx4025', 1);
+		$this->expectExceptionMessageMatches('~No plate~');
+		$this->encoder->addWellToPlate(1, 4, 5);
+	}
+
+	public function testAddWellToPlateTwice() {
+		$this->encoder->createShipment('mx4025', 1);
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$this->encoder->addWellToPlate($plate['index'], 4, 5);
+		$this->expectExceptionMessageMatches('~already exists~');
+		$this->encoder->addWellToPlate($plate['index'], 4, 5);
+	}
+
+	public function testAddWellToPlateBadRowNumber() {
+		$this->encoder->createShipment('mx4025', 1);
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$this->expectExceptionMessageMatches('~Row number must be between~');
+		$this->encoder->addWellToPlate($plate['index'], 0, 5);
+	}
+
+	public function testAddWellToPlateBadColumnNumber() {
+		$this->encoder->createShipment('mx4025', 1);
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$this->expectExceptionMessageMatches('~Column number must be between~');
+		$this->encoder->addWellToPlate($plate['index'], 4, 0);
+	}
+
+	public function testAddDropToPlateWell() {
+		$this->encoder->createShipment('mx4025', 1);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$well = $this->encoder->addWellToPlate($plate['index'], 4, 7);
+		$ret = $this->encoder->addDropToPlateWell($well['index'], 1, 1);
+		$this->assertArrayHasKey('MacromoleculeSample', $ret);
+		$this->assertArrayHasKey('WellDrop', $ret);
+		$this->assertEquals('#/Macromolecule/Macromolecule' . $macromolecule['index'], $ret['MacromoleculeSample']['macromoleculeRef']['$ref']);
+		$this->assertEquals('BARCODE1234_D07_1', $ret['WellDrop']['name']);
+		$this->assertEquals('#/PlateWell/PlateWell' . $well['index'], $ret['WellDrop']['containerRef']['$ref']);
+		$this->assertEquals('#/MacromoleculeSample/MacromoleculeSample' . $ret['MacromoleculeSample']['index'], $ret['WellDrop']['sampleRef']['$ref']);
+		$this->assertArrayHasKey('index', $ret['MacromoleculeSample']);
+		$this->assertArrayHasKey('index', $ret['WellDrop']);
+	}
+
+	public function testAddTwoDropsToSamePlateWell() {
+		$this->encoder->createShipment('mx4025', 1);
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$well = $this->encoder->addWellToPlate($plate['index'], 4, 7);
+		$this->encoder->addDropToPlateWell($well['index'], 1, 1);
+		$ret = $this->encoder->addDropToPlateWell($well['index'], 2, 1);
+		$this->assertArrayHasKey('WellDrop', $ret);
+		$this->assertArrayHasKey('MacromoleculeSample', $ret);
+		$this->assertArrayHasKey('index', $ret['MacromoleculeSample']);
+		$this->assertArrayHasKey('index', $ret['WellDrop']);
+		$this->assertEquals('#/Macromolecule/Macromolecule' . $macromolecule['index'], $ret['MacromoleculeSample']['macromoleculeRef']['$ref']);
+		$this->assertEquals('BARCODE1234_D07_2', $ret['WellDrop']['name']);
+		$this->assertEquals('#/PlateWell/PlateWell' . $well['index'], $ret['WellDrop']['containerRef']['$ref']);
+		$this->assertEquals('#/MacromoleculeSample/MacromoleculeSample' . $ret['MacromoleculeSample']['index'], $ret['WellDrop']['sampleRef']['$ref']);
+	}
+
+	public function testAddDropToPlateWellWithSampleName() {
+		$this->encoder->createShipment('mx4025', 1);
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$well = $this->encoder->addWellToPlate($plate['index'], 4, 7);
+		$ret = $this->encoder->addDropToPlateWell($well['index'], 1, 1, 'sampleName');
+		$this->assertEquals('sampleName', $ret['WellDrop']['name']);
+	}
+
+	public function testAddDropToPlateWellNoWell() {
+		$this->expectExceptionMessageMatches('~No well with index~');
+		$this->encoder->addDropToPlateWell(1, 1, 1);
+	}
+
+	public function testAddDropToPlateWellNoMacromolecule() {
+		$this->encoder->createShipment('mx4025', 1);
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$this->encoder->addWellToPlate($plate['index'], 4, 7);
+		$this->expectExceptionMessageMatches('~No macromolecule with index~');
+		$this->encoder->addDropToPlateWell(1, 1, 1);
+	}
+
+	public function testAddDropToPlateWellDuplicateDrop() {
+		$this->encoder->createShipment('mx4025', 1);
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$this->encoder->addWellToPlate($plate['index'], 4, 7);
+		$this->expectExceptionMessageMatches('~drop already exists~');
+		$this->encoder->addDropToPlateWell(1, 1, 1);
+		$this->encoder->addDropToPlateWell(1, 1, 1);
+	}
+
+	public function testAddDropToPlateWellBadDropNumber() {
+		$this->encoder->createShipment('mx4025', 1);
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$this->encoder->addWellToPlate($plate['index'], 4, 7);
+		$this->expectExceptionMessageMatches('~Drop number must be between~');
+		$this->encoder->addDropToPlateWell(1, 6, 1);
+	}
+
+	public function testAddDropToPlateWellDuplicateSampleName() {
+		$this->encoder->createShipment('mx4025', 1);
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$this->encoder->addWellToPlate($plate['index'], 4, 7);
+		$this->expectExceptionMessageMatches('~name already exists~');
+		$this->encoder->addDropToPlateWell(1, 1, 1, 'sampleName');
+		$this->encoder->addDropToPlateWell(1, 2, 1, 'sampleName');
+	}
+
+	private function createPlateAndDrop(): array {
+		$this->encoder->createShipment('mx4025', 1);
+		$plate = $this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$well=$this->encoder->addWellToPlate($plate['index'], 4, 7);
+		$macromolecule=$this->encoder->addMacromoleculeToShipment('TEST');
+		$ret=$this->encoder->addDropToPlateWell($well['index'], 3, $macromolecule['index']);
+		$ret['WellDrop']['plateIndex']=$plate['index'];
+		$ret['WellDrop']['wellIndex']=$well['index'];
+		$ret['WellDrop']['rowNumber']=$well['rowNumber'];
+		$ret['WellDrop']['columnNumber']=$well['columnNumber'];
+		$ret['WellDrop']['macromoleculeIndex']=$macromolecule['index'];
+		return $ret['WellDrop'];
+	}
+
+	public function testAddPlatePointDropRegionByPlateDropIndex(){
+		$drop=$this->createPlateAndDrop();
+		$region=$this->encoder->addPointDropRegionByPlateDropIndex($drop['index'], 100, 200);
+		$this->assertArrayHasKey('region', $region);
+		$this->assertArrayHasKey('uuid', $region);
+		$this->assertArrayHasKey('index', $region);
+		$this->assertEquals('DropRegion', $region['mxlimsType']);
+		$this->assertEquals($this->version, $region['version']);
+		$this->assertEquals('#/WellDrop/WellDrop'.$drop['index'], $region['containerRef']['$ref']);
+		$this->assertEquals('micron', $region['region']['units']);
+		$this->assertEquals('point', $region['region']['region']['regionType']);
+		$this->assertEquals(100, $region['region']['region']['x']);
+		$this->assertEquals(200, $region['region']['region']['y']);
+	}
+
+	public function testAddPlatePointDropRegionByPlateDropIndexWithMimeType(){
+		$drop=$this->createPlateAndDrop();
+		$this->expectExceptionMessageMatches('~Do not set image MIME type~');
+		$this->encoder->addPointDropRegionByPlateDropIndex($drop['index'], 100, 200, 'text/plain');
+	}
+
+	public function testAddImagePointDropRegionByPlateDropIndex(){
+		$drop=$this->createPlateAndDrop();
+		$region=$this->encoder->addPointDropRegionByPlateDropIndex($drop['index'], 100, 200, 'image/jpeg', 'http://image.url/1234');
+		$this->assertArrayHasKey('index', $region);
+		$this->assertEquals('DropRegion', $region['mxlimsType']);
+		$this->assertEquals($this->version, $region['version']);
+		$this->assertArrayHasKey('uuid', $region);
+		$this->assertEquals('#/WellDrop/WellDrop'.$drop['index'], $region['containerRef']['$ref']);
+		$this->assertArrayHasKey('region', $region);
+		$this->assertEquals('pixel', $region['region']['units']);
+		$this->assertEquals('point', $region['region']['region']['regionType']);
+		$this->assertEquals(100, $region['region']['region']['x']);
+		$this->assertEquals(200, $region['region']['region']['y']);
+	}
+
+	public function testAddImagePointDropRegionNoMimeType() {
+		$drop=$this->createPlateAndDrop();
+		$this->expectExceptionMessageMatches('~No image MIME type~');
+		$this->encoder->addPointDropRegionByPlateDropIndex($drop['index'], 100, 200, null, 'http://image.url/1234');
+	}
+
+	public function testAddImagePointDropRegionBadMimeType() {
+		$drop=$this->createPlateAndDrop();
+		$this->expectExceptionMessageMatches('~Bad image MIME type~');
+		$this->encoder->addPointDropRegionByPlateDropIndex($drop['index'], 100, 200, 'text/plain', 'http://image.url/1234');
+	}
+
+	public function testAddImagePointDropRegionBothUrlAndData() {
+		$drop=$this->createPlateAndDrop();
+		$this->expectExceptionMessageMatches('~both imageUrl and imageData~');
+		$this->encoder->addPointDropRegionByPlateDropIndex($drop['index'], 100, 200, 'image/jpeg', 'http://image.url/1234', 'df2ys3dy5gd2grt7e');
+	}
+
+	public function testAddImagePointDropRegionBadUrl() {
+		$drop=$this->createPlateAndDrop();
+		$this->expectExceptionMessageMatches('~Bad image URL~');
+		$this->encoder->addPointDropRegionByPlateDropIndex($drop['index'], 100, 200, 'image/jpeg', 'http:/image.url/1234');
+	}
+
+	public function testAddImagePointDropRegionBadCoordinate() {
+		$drop=$this->createPlateAndDrop();
+		$this->expectExceptionMessageMatches('~cannot be negative~');
+		$this->encoder->addPointDropRegionByPlateDropIndex($drop['index'], 100, -200, 'image/jpeg', 'http://image.url/1234');
+	}
+
+	public function testAddCrystalToDropRegion() {
+		$drop=$this->createPlateAndDrop();
+		$region=$this->encoder->addPointDropRegionByPlateDropIndex($drop['index'], 100, 200);
+		$crystal=$this->encoder->addCrystalToDropRegion($region['index'], 'CRYSTAL_NAME');
+		$this->assertArrayHasKey('uuid', $crystal);
+		$this->assertEquals('Crystal', $crystal['mxlimsType']);
+		$this->assertEquals('CRYSTAL_NAME', $crystal['name']);
+		$this->assertEquals('#/DropRegion/DropRegion'.$region['index'], $crystal['containerRef']['$ref']);
+		$this->assertEquals($drop['sampleRef']['$ref'], $crystal['sampleRef']['$ref']);
+	}
+
+	public function testValidateNoShipment() {
+		$this->expectExceptionMessageMatches('~No shipment~');
+		$this->encoder->validate();
+	}
+
+	public function testValidateNoLabContactOutbound() {
+		$this->encoder->createShipment('mx4025');
+		$this->expectExceptionMessageMatches('~lab contact~');
+		$this->encoder->validate();
+	}
+
+	public function testValidateNoLabContactReturn() {
+		$this->encoder->createShipment('mx4025');
+		$this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->expectExceptionMessageMatches('~lab contact~');
+		$this->encoder->validate();
+	}
+
+	public function testValidateNoDewarsOrPlates() {
+		$this->encoder->createShipment('mx4025');
+		$this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob', 'bob@bob.com');
+		$this->expectExceptionMessageMatches('~Dewars or Plates~');
+		$this->encoder->validate();
+	}
+
+	public function testValidateSinglePositionPinButNoSamples() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob', 'bob@bob.com');
+		$this->encoder->addSinglePositionPinToPuck($puck['index'], 4, 'PIN1');
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$this->expectExceptionMessageMatches('~No MacromoleculeSamples~');
+		$this->encoder->validate();
+	}
+
+	public function testValidateMultiPositionPinButNoSamples() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob', 'bob@bob.com');
+		$this->encoder->addMultiPositionPinToPuck($puck['index'], 4, 8, 'MULTIPIN1');
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$this->expectExceptionMessageMatches('~No PinPositions~');
+		$this->encoder->validate();
+	}
+
+	public function testValidatePlateButNoWells(){
+		$this->encoder->createShipment('mx4025');
+		$this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob', 'bob@bob.com');
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$this->expectExceptionMessageMatches('~No PlateWells~');
+		$this->encoder->validate();
+	}
+
+	public function testValidatePlateWellButNoDrops(){
+		$this->encoder->createShipment('mx4025');
+		$this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob', 'bob@bob.com');
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$plate=$this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$this->encoder->addWellToPlate($plate['index'], 1, 1);
+		$this->expectExceptionMessageMatches('~No WellDrops~');
+		$this->encoder->validate();
+	}
+
+	public function testValidatePlateButNoDropRegions(){
+		$this->encoder->createShipment('mx4025');
+		$macromolecule=$this->encoder->addMacromoleculeToShipment('TEST');
+		$this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob', 'bob@bob.com');
+		$plate=$this->encoder->addPlateToShipment('BARCODE1234', 8, 12, 3);
+		$well=$this->encoder->addWellToPlate($plate['index'], 1, 1);
+		$this->encoder->addDropToPlateWell($well['index'], 1, $macromolecule['index']);
+		$this->expectExceptionMessageMatches('~No DropRegions~');
+		$this->encoder->validate();
+	}
+
+	public function testValidateDropRegionButNoCrystal(){
+		$drop=$this->createPlateAndDrop();
+		$this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob', 'bob@bob.com');
+		$this->encoder->addPointDropRegionByPlateDropIndex($drop['index'], 100, 200);
+		$this->expectExceptionMessageMatches('~No crystal~');
+		$this->encoder->validate();
+	}
+
+	public function testValidateValidPlateShipment() {
+		$drop=$this->createPlateAndDrop();
+		$this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob', 'bob@bob.com');
+		$region=$this->encoder->addPointDropRegionByPlateDropIndex($drop['index'], 100, 200);
+		$this->encoder->addCrystalToDropRegion($region['index'], 'CRYSTAL_NAME');
+		$result=$this->encoder->validate();
+		self::assertTrue($result);
+	}
+
+	public function testValidateDewarButNoPucks() {
+		$this->encoder->createShipment('mx4025');
+		$this->encoder->setLabContactOutbound('Bob','bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob','bob@bob.com');
+		$this->encoder->addDewarToShipment('DLS-MX-1234');
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$this->expectExceptionMessageMatches('~No Pucks~');
+		$this->encoder->validate();
+	}
+
+	public function testValidateNoMacromolecules() {
+		$this->encoder->createShipment('mx4025');
+		$this->encoder->setLabContactOutbound('Bob','bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob','bob@bob.com');
+		$this->encoder->addDewarToShipment('DLS-MX-1234');
+		$this->encoder->addPuckToDewar(1, 'OUL-999', 16);
+		$this->expectExceptionMessageMatches('~No Macromolecules~');
+		$this->encoder->validate();
+	}
+
+	public function testValidateNoPinsOrMultiPins() {
+		$this->encoder->createShipment('mx4025');
+		$this->encoder->setLabContactOutbound('Bob','bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob','bob@bob.com');
+		$this->encoder->addDewarToShipment('DLS-MX-1234');
+		$this->encoder->addPuckToDewar(1, 'OUL-999', 16);
+		$this->encoder->addMacromoleculeToShipment('TEST');
+		$this->expectExceptionMessageMatches('~No Pins or MultiPins~');
+		$this->encoder->validate();
+	}
+
+	/**
+	 * @param $json
+	 * @return void
+	 * @throws \Exception
+	 */
+	private function validateJsonAgainstSchema($json): void {
+		$command=@file_get_contents(__DIR__.'/SchemaValidationCommand');
+		if(!$command){ $this->markTestSkipped('No SchemaValidationCommand file found'); }
+
+		$encoderVersion=$this->encoder->getVersion();
+		$objectSchema=@file_get_contents(__DIR__.'/../../../../schemas/data/MxlimsObjectData.json');
+		if(!$objectSchema){
+			throw new \Exception('Could not open ShipmentMessage schema to determine version number');
+		}
+		$objectSchema=json_decode($objectSchema, true);
+		if(!$objectSchema){
+			throw new \Exception('Could not parse ShipmentMessage schema');
+		}
+		$schemaVersion=$objectSchema['properties']['version']['const'];
+		if($schemaVersion!==$encoderVersion){
+			$this->markTestSkipped("Version mismatch: Local MXLIMS schema copy $schemaVersion does not match generated shipment $encoderVersion. Cannot validate against schema.");
+		}
+
+		$jsonPath=str_replace('/', DIRECTORY_SEPARATOR,__DIR__.'/test.json');
+		$schemaPath=str_replace('/', DIRECTORY_SEPARATOR,__DIR__.'/../../../../schemas/messages/ShipmentMessage.json');
+		if(!@file_put_contents($jsonPath, $json)){
+			$this->fail('Could not write test JSON to disk for parsing');
+		}
+		$command=str_replace('{{$jsonFile}}', $jsonPath, $command);
+		$command=str_replace('{{$schemaFile}}', $schemaPath, $command);
+		$result=(exec($command));
+		$acceptableResults=['True'];
+		if(!in_array($result, $acceptableResults)){
+			echo $json;
+		}
+		$this->assertContains($result, $acceptableResults);
+	}
+
+	/**
+	 * @throws \Exception
+	 */
+	public function testSinglePinJsonValidatesAgainstSchema() {
+		$this->encoder->createShipment('mx4025', 4);
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$macromolecule=$this->encoder->addMacromoleculeToShipment("TEST");
+		$this->encoder->addSinglePinSampleToPuck($puck['index'], 1, $macromolecule['index'], 'TEST_9098A01d1c1', 'HA00AA5432');
+		$this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob', 'bob@bob.com');
+		$json=$this->encoder->encodeToJSON();
+		$this->validateJsonAgainstSchema($json);
+	}
+
+	/**
+	 * @throws \Exception
+	 */
+	public function testMultiPinJsonValidatesAgainstSchema() {
+		$this->encoder->createShipment('mx4025', 4);
+		$this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob', 'bob@bob.com');
+		$dewar = $this->encoder->addDewarToShipment('DLS-MX-1234');
+		$puck = $this->encoder->addPuckToDewar($dewar['index'], 'OUL-999', 16);
+		$pin = $this->encoder->addMultiPositionPinToPuck($puck['index'], 10, 8, 'MULTIPIN1');
+		$macromolecule = $this->encoder->addMacromoleculeToShipment('TEST');
+		$this->encoder->addSampleToMultiPositionPin($pin['index'], 1, $macromolecule['index'], 'TEST_9098A01d1c1');
+		$json=$this->encoder->encodeToJSON();
+		$this->validateJsonAgainstSchema($json);
+	}
+
+	/**
+	 * @throws \Exception
+	 */
+	public function testPlateJsonValidatesAgainstSchema() {
+		$drop=$this->createPlateAndDrop();
+		$this->encoder->setLabContactOutbound('Bob', 'bob@bob.com');
+		$this->encoder->setLabContactReturn('Bob', 'bob@bob.com');
+		$region=$this->encoder->addPointDropRegionByPlateDropIndex($drop['index'], 100, 200);
+		$this->encoder->addCrystalToDropRegion($region['index'], 'CRYSTAL_NAME');
+		$json=$this->encoder->encodeToJSON(true);
+		$this->validateJsonAgainstSchema($json);
+	}
+
+}

--- a/mxlims/tools/php/ShipmentEncoder/test/v0_6_5ShipmentEncoderTest.php
+++ b/mxlims/tools/php/ShipmentEncoder/test/v0_6_5ShipmentEncoderTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace mxlims\tools\php\ShipmentEncoder\test;
+
+include_once 'v0_6_4ShipmentEncoderTest.php';
+
+class v0_6_5ShipmentEncoderTest extends v0_6_4ShipmentEncoderTest {
+	// Overwrite any 0.6.4 tests here, and add new ones.
+}


### PR DESCRIPTION
This PR adds PHP code and tests for a "shipment encoder", which can generate an MXLIMS ShipmentMessage conforming to 0.6.4. Traditional loops, multi-position pins, and plate shipments (with point "regions" only) are supported.

Some schema changes are included, namely:

Adding a "pattern" property with a UUID regex wherever the schemas have the non-standard (but widely supported) "format":"uuid", as discussed with Rasmus; and

Making "image" required in ImageRegion, otherwise a PlateRegion conforms to both PlateRegion and ImageRegion, violating a oneOf constraint and preventing validation.